### PR TITLE
R26-292 Commands fix

### DIFF
--- a/src/main/java/frc/robot/subsystems/climb/Climb.java
+++ b/src/main/java/frc/robot/subsystems/climb/Climb.java
@@ -22,7 +22,6 @@ import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.Relay;
 import edu.wpi.first.wpilibj.Relay.Value;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.util.TunableConstant;
 
 @Logged
 public class Climb extends SubsystemBase {
@@ -176,28 +175,19 @@ public class Climb extends SubsystemBase {
     pivotClimbController.setPID(kPivotP, kPivotI, kPivotD);
   }
 
-  public void tuneClimb() {
-    TunableConstant kP = new TunableConstant("/Climb/kP", 0);
-    TunableConstant kD = new TunableConstant("/Climb/kD", 0);
-    TunableConstant kG = new TunableConstant("/Climb/kG", 0);
-    TunableConstant kTargetAngle = new TunableConstant("/Climb/kTargetAngle", 0);
-
-    climbController.setPID(kP.get(), 0, kD.get());
-    climbFeedforward.setKg(kG.get());
-    goToAngle(Degrees.of(kTargetAngle.get()));
+  public void tuneClimb(double kP, double kD, double kG, double kTargetAngle) {
+    climbController.setPID(kP, 0, kD);
+    climbFeedforward.setKg(kG);
+    goToAngle(Degrees.of(kTargetAngle));
   }
 
   public void setClimbFeedforward(double kG) {
     climbFeedforward.setKg(kG);
   }
 
-  public void tunePivotClimb() {
-    TunableConstant kPivotP = new TunableConstant("/Climb/kPivotP", 0);
-    TunableConstant kPivotD = new TunableConstant("/Climb/kPivotD", 0);
-    TunableConstant pivotTargetAngle = new TunableConstant("/Climb/pivotTargetAngle", 0);
-
-    pivotClimbController.setPID(kPivotP.get(), 0, kPivotD.get());
-    goToPivotAngle(Degrees.of(pivotTargetAngle.get()));
+  public void tunePivotClimb(double kPivotP, double kPivotD, double kPivotTargetAngle) {
+    pivotClimbController.setPID(kPivotP, 0, kPivotD);
+    goToPivotAngle(Degrees.of(kPivotTargetAngle));
   }
 
   public void turnOnMagnet() {

--- a/src/main/java/frc/robot/subsystems/climb/climbCommands/ClimbTuning.java
+++ b/src/main/java/frc/robot/subsystems/climb/climbCommands/ClimbTuning.java
@@ -3,17 +3,21 @@ package frc.robot.subsystems.climb.climbCommands;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.climb.Climb;
+import frc.robot.util.TunableConstant;
 
 public class ClimbTuning extends Command {
-
   Climb climb;
+  TunableConstant kP = new TunableConstant("/Climb/kP", 0);
+  TunableConstant kD = new TunableConstant("/Climb/kD", 0);
+  TunableConstant kG = new TunableConstant("/Climb/kG", 0);
+  TunableConstant kTargetAngle = new TunableConstant("/Climb/kTargetAngle", 0);
 
   public ClimbTuning(Climb climb) {
     this.climb = climb;
   }
 
   public void execute() {
-    climb.tuneClimb();
+    climb.tuneClimb(kP.get(), kD.get(), kG.get(), kTargetAngle.get());
   }
 
   public boolean isFinished() {

--- a/src/main/java/frc/robot/subsystems/climb/climbCommands/PivotClimbTuning.java
+++ b/src/main/java/frc/robot/subsystems/climb/climbCommands/PivotClimbTuning.java
@@ -3,17 +3,21 @@ package frc.robot.subsystems.climb.climbCommands;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.climb.Climb;
+import frc.robot.util.TunableConstant;
 
 public class PivotClimbTuning extends Command {
-
   Climb climb;
+  TunableConstant kPivotP = new TunableConstant("/Climb/kPivotP", 0);
+  TunableConstant kPivotD = new TunableConstant("/Climb/kPivotD", 0);
+  TunableConstant kPivotTargetAngle = new TunableConstant("/Climb/kPivotTargetAngle", 0);
 
   public PivotClimbTuning(Climb climb) {
+
     this.climb = climb;
   }
 
   public void execute() {
-    climb.tunePivotClimb();
+    climb.tunePivotClimb(kPivotP.get(), kPivotD.get(), kPivotTargetAngle.get());
   }
 
   public boolean isFinished() {

--- a/src/main/java/frc/robot/subsystems/hood/Hood.java
+++ b/src/main/java/frc/robot/subsystems/hood/Hood.java
@@ -20,7 +20,6 @@ import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.util.TunableConstant;
 
 @Logged
 public class Hood extends SubsystemBase {
@@ -66,14 +65,7 @@ public class Hood extends SubsystemBase {
   }
 
   public void setHoodPID(double kP, double kD, double kG) {
-    hoodMotor
-        .getConfigurator()
-        .apply(
-            new Slot0Configs()
-                .withKP(kP)
-                .withKD(kD)
-                .withKG(kG)
-                .withStaticFeedforwardSign(StaticFeedforwardSignValue.UseClosedLoopSign));
+    hoodMotor.getConfigurator().apply(new Slot0Configs().withKP(kP).withKD(kD).withKG(kG));
   }
 
   public void goToAngle(Angle targetAngle) {
@@ -97,15 +89,9 @@ public class Hood extends SubsystemBase {
     return atTargetAngle;
   }
 
-  public void tune() {
-    TunableConstant kG = new TunableConstant("Hood/kG/", 0);
-    TunableConstant kD = new TunableConstant("Hood/kD/", 0);
-    TunableConstant kP = new TunableConstant("Hood/kP/", 0);
-    TunableConstant targetAngle = new TunableConstant("Hood/targetAngle/", 0);
-
-    setHoodPID(kP.get(), kD.get(), kG.get());
-
-    goToAngle(Degrees.of(targetAngle.get()));
+  public void tune(double kP, double kD, double kG, double targetAngle) {
+    setHoodPID(kP, kD, kG);
+    goToAngle(Degrees.of(targetAngle));
   }
 
   @Logged(name = "targetPitch")

--- a/src/main/java/frc/robot/subsystems/hood/hoodCommands/HoodCommands.java
+++ b/src/main/java/frc/robot/subsystems/hood/hoodCommands/HoodCommands.java
@@ -11,7 +11,7 @@ import java.util.function.Supplier;
 public class HoodCommands {
 
   public static Command goToAngle(Hood hood, Supplier<Angle> angle) {
-    return Commands.run(() -> hood.goToAngle(angle.get()));
+    return Commands.run(() -> hood.goToAngle(angle.get()), hood);
   }
 
   public static Command goToScoringAngle(Hood hood) {

--- a/src/main/java/frc/robot/subsystems/hood/hoodCommands/TuneHood.java
+++ b/src/main/java/frc/robot/subsystems/hood/hoodCommands/TuneHood.java
@@ -2,11 +2,26 @@
 package frc.robot.subsystems.hood.hoodCommands;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.subsystems.hood.Hood;
+import frc.robot.util.TunableConstant;
 
-public class TuneHood {
-  public static Command tune(Hood hood) {
-    return Commands.run(() -> hood.tune());
+public class TuneHood extends Command {
+  Hood hood;
+  TunableConstant kP = new TunableConstant("Hood/kP/", 0);
+  TunableConstant kD = new TunableConstant("Hood/kD/", 0);
+  TunableConstant kG = new TunableConstant("Hood/kG/", 0);
+  TunableConstant targetAngle = new TunableConstant("Hood/targetAngle/", 0);
+
+  public TuneHood(Hood hood) {
+
+    this.hood = hood;
+  }
+
+  public void execute() {
+    hood.tune(kP.get(), kD.get(), kG.get(), targetAngle.get());
+  }
+
+  public boolean isFinished() {
+    return false;
   }
 }

--- a/src/main/java/frc/robot/subsystems/indexer/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/Indexer.java
@@ -20,7 +20,6 @@ import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Velocity;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.util.TunableConstant;
 
 @Logged
 public class Indexer extends SubsystemBase {
@@ -32,7 +31,7 @@ public class Indexer extends SubsystemBase {
 
   public Indexer() {
     configureMotors();
-    setPID();
+    setPID(IndexerConstants.kP, IndexerConstants.kD, IndexerConstants.kV);
   }
 
   public void configureMotors() {
@@ -61,12 +60,8 @@ public class Indexer extends SubsystemBase {
     motor.getConfigurator().apply(configurations);
   }
 
-  public void setPID() {
-    Slot0Configs pidConfigs =
-        new Slot0Configs()
-            .withKP(IndexerConstants.kP)
-            .withKD(IndexerConstants.kD)
-            .withKV(IndexerConstants.kV);
+  public void setPID(double kP, double kD, double kV) {
+    Slot0Configs pidConfigs = new Slot0Configs().withKP(kP).withKD(kD).withKV(kV);
 
     motor.getConfigurator().apply(pidConfigs);
   }
@@ -79,20 +74,9 @@ public class Indexer extends SubsystemBase {
     motor.setVoltage(voltage.in(Volts));
   }
 
-  public void tune() {
-    TunableConstant kP = new TunableConstant("Indexer/kP/", 0);
-
-    TunableConstant kD = new TunableConstant("Indexer/kD/", 0);
-
-    TunableConstant kV = new TunableConstant("Indexer/kV/", 0);
-
-    TunableConstant targetSpeed = new TunableConstant("Indexer/targetSpeed", 0);
-
-    IndexerConstants.kP = kP.get();
-    IndexerConstants.kV = kV.get();
-    IndexerConstants.kD = kD.get();
-
-    goToVelocity(RPM.of(targetSpeed.get()));
+  public void tune(double kP, double kD, double kV, double targetSpeed) {
+    setPID(kP, kD, kV);
+    goToVelocity(RPM.of(targetSpeed));
   }
 
   @Logged

--- a/src/main/java/frc/robot/subsystems/indexer/indexerCommands/Index.java
+++ b/src/main/java/frc/robot/subsystems/indexer/indexerCommands/Index.java
@@ -12,11 +12,11 @@ import java.util.function.Supplier;
 public class Index {
 
   public static Command setVoltage(Indexer indexer, Supplier<Voltage> voltage) {
-    return Commands.run(() -> indexer.setVoltage(voltage.get()),indexer);
+    return Commands.run(() -> indexer.setVoltage(voltage.get()), indexer);
   }
 
   public static Command goToVelocity(Indexer indexer, Supplier<AngularVelocity> velocity) {
-    return Commands.run(() -> indexer.goToVelocity(velocity.get()));
+    return Commands.run(() -> indexer.goToVelocity(velocity.get()), indexer);
   }
 
   public static Command index(Indexer indexer) {

--- a/src/main/java/frc/robot/subsystems/indexer/indexerCommands/Index.java
+++ b/src/main/java/frc/robot/subsystems/indexer/indexerCommands/Index.java
@@ -12,7 +12,7 @@ import java.util.function.Supplier;
 public class Index {
 
   public static Command setVoltage(Indexer indexer, Supplier<Voltage> voltage) {
-    return Commands.run(() -> indexer.setVoltage(voltage.get()));
+    return Commands.run(() -> indexer.setVoltage(voltage.get()),indexer);
   }
 
   public static Command goToVelocity(Indexer indexer, Supplier<AngularVelocity> velocity) {

--- a/src/main/java/frc/robot/subsystems/indexer/indexerCommands/TuneIndexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/indexerCommands/TuneIndexer.java
@@ -2,12 +2,25 @@
 package frc.robot.subsystems.indexer.indexerCommands;
 
 import edu.wpi.first.wpilibj2.command.Command;
-import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.subsystems.indexer.Indexer;
+import frc.robot.util.TunableConstant;
 
-public class TuneIndexer {
+public class TuneIndexer extends Command {
+  Indexer indexer;
+  TunableConstant kP = new TunableConstant("Indexer/kP/", 0);
+  TunableConstant kD = new TunableConstant("Indexer/kD/", 0);
+  TunableConstant kV = new TunableConstant("Indexer/kV/", 0);
+  TunableConstant targetSpeed = new TunableConstant("Indexer/targetSpeed", 0);
 
-  public static Command tune(Indexer indexer) {
-    return Commands.run(() -> indexer.tune());
+  public TuneIndexer(Indexer indexer) {
+    this.indexer = indexer;
+  }
+
+  public void execute() {
+    indexer.tune(kP.get(), kD.get(), kV.get(), targetSpeed.get());
+  }
+
+  public boolean isFinished() {
+    return false;
   }
 }

--- a/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
@@ -6,7 +6,6 @@ import static edu.wpi.first.units.Units.Degrees;
 import edu.wpi.first.units.measure.Angle;
 
 public class IntakeConstants {
-
   public static final int kPivotMotorId = 0;
   public static final double kCurrentLimits = 0;
   public static final double kCurrentLimit = 0;

--- a/src/main/java/frc/robot/subsystems/intakePivot/IntakePivot.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/IntakePivot.java
@@ -43,6 +43,7 @@ public class IntakePivot extends SubsystemBase {
 
   public IntakePivot() {
     motorConfigurations();
+    setPID(IntakeConstants.kP, IntakeConstants.kD, IntakeConstants.kG);
   }
 
   private void motorConfigurations() {

--- a/src/main/java/frc/robot/subsystems/intakePivot/IntakePivot.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/IntakePivot.java
@@ -11,8 +11,10 @@ import com.ctre.phoenix6.configs.TalonFXConfiguration;
 import com.ctre.phoenix6.configs.VoltageConfigs;
 import com.ctre.phoenix6.controls.MotionMagicVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;
+import com.ctre.phoenix6.signals.GravityTypeValue;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
+import com.ctre.phoenix6.signals.StaticFeedforwardSignValue;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Current;
@@ -20,7 +22,6 @@ import edu.wpi.first.units.measure.Velocity;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.util.TunableConstant;
 
 @Logged(name = "Intake Pivot")
 public class IntakePivot extends SubsystemBase {
@@ -50,9 +51,8 @@ public class IntakePivot extends SubsystemBase {
     currentLimitsConfigs.withStatorCurrentLimitEnable(IntakeConstants.kCurrentLimitEnable);
     currentLimitsConfigs.withStatorCurrentLimit(IntakeConstants.kCurrentLimit);
 
-    slot0Configs.withKG(IntakeConstants.kG);
-    slot0Configs.withKD(IntakeConstants.kD);
-    slot0Configs.withKP(IntakeConstants.kP);
+    slot0Configs.withGravityType(GravityTypeValue.Arm_Cosine);
+    slot0Configs.withStaticFeedforwardSign(StaticFeedforwardSignValue.UseClosedLoopSign);
 
     feedbackConfigs.withSensorToMechanismRatio(IntakeConstants.kSensorToMechanismRatio);
 
@@ -81,18 +81,13 @@ public class IntakePivot extends SubsystemBase {
     return getAngle() == targetAngle;
   }
 
-  public void tune() {
+  public void setPID(double kP, double kD, double kG) {
+    intakePivotMotor.getConfigurator().apply(new Slot0Configs().withKP(kP).withKD(kD).withKG(kG));
+  }
 
-    TunableConstant kP = new TunableConstant("/IntakePivot/kP", 0);
-    TunableConstant kD = new TunableConstant("/IntakePivot/kD", 0);
-    TunableConstant kG = new TunableConstant("/IntakePivot/kG", 0);
-    TunableConstant angle = new TunableConstant("/IntakePivot/angle", 0);
-
-    IntakeConstants.kP = kP.get();
-    IntakeConstants.kD = kD.get();
-    IntakeConstants.kG = kG.get();
-
-    goToAngle(Degrees.of(angle.get()));
+  public void tune(double kP, double kD, double kG, double angle) {
+    setPID(kP, kD, kG);
+    goToAngle(Degrees.of(angle));
   }
 
   @Logged

--- a/src/main/java/frc/robot/subsystems/intakePivot/intakePivotCommands/Tune.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/intakePivotCommands/Tune.java
@@ -2,16 +2,21 @@
 package frc.robot.subsystems.intakePivot.intakePivotCommands;
 
 import frc.robot.subsystems.intakePivot.IntakePivot;
+import frc.robot.util.TunableConstant;
 
 public class Tune {
 
   IntakePivot intakePivot;
+  TunableConstant kP = new TunableConstant("/IntakePivot/kP", 0);
+  TunableConstant kD = new TunableConstant("/IntakePivot/kD", 0);
+  TunableConstant kG = new TunableConstant("/IntakePivot/kG", 0);
+  TunableConstant angle = new TunableConstant("/IntakePivot/angle", 0);
 
   public Tune(IntakePivot intakePivot) {
     this.intakePivot = intakePivot;
   }
 
   public void execute() {
-    intakePivot.tune();
+    intakePivot.tune(kP.get(), kD.get(), kG.get(), angle.get());
   }
 }

--- a/src/main/java/frc/robot/subsystems/intakePivot/intakePivotCommands/Tune.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/intakePivotCommands/Tune.java
@@ -1,10 +1,11 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.intakePivot.intakePivotCommands;
 
+import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.intakePivot.IntakePivot;
 import frc.robot.util.TunableConstant;
 
-public class Tune {
+public class Tune extends Command{
 
   IntakePivot intakePivot;
   TunableConstant kP = new TunableConstant("/IntakePivot/kP", 0);

--- a/src/main/java/frc/robot/subsystems/intakePivot/intakePivotCommands/Tune.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/intakePivotCommands/Tune.java
@@ -5,7 +5,7 @@ import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.intakePivot.IntakePivot;
 import frc.robot.util.TunableConstant;
 
-public class Tune extends Command{
+public class Tune extends Command {
 
   IntakePivot intakePivot;
   TunableConstant kP = new TunableConstant("/IntakePivot/kP", 0);

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
@@ -11,7 +11,6 @@ import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.units.measure.Velocity;
-import frc.robot.util.TunableConstant;
 
 @Logged
 public class IntakeRollers {
@@ -60,14 +59,8 @@ public class IntakeRollers {
     rollerMotor.getConfigurator().apply(slot0Configs);
   }
 
-  public void tune() {
-
-    TunableConstant kP = new TunableConstant("IntakeRollers/kP", 0);
-    TunableConstant kD = new TunableConstant("IntakeRollers/kD", 0);
-    TunableConstant kG = new TunableConstant("IntakeRollers/kG", 0);
-    TunableConstant kV = new TunableConstant("IntakeRollers/kV", 0);
-
-    setPID(kP.get(), kD.get(), kV.get(), kG.get());
+  public void tune(double kP, double kD, double kV, double kG) {
+    setPID(kP, kD, kV, kG);
   }
 
   @Logged(name = "rollerVelocity")

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
@@ -15,9 +15,10 @@ import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.units.measure.Velocity;
 import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 @Logged
-public class IntakeRollers {
+public class IntakeRollers extends SubsystemBase {
 
   @Logged private TalonFX rollerMotor = new TalonFX(IntakeRollerConstants.kRollerMotorId);
   private CurrentLimitsConfigs currentLimitsConfigs = new CurrentLimitsConfigs();

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
@@ -14,6 +14,7 @@ import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.units.measure.Velocity;
+import edu.wpi.first.units.measure.Voltage;
 
 @Logged
 public class IntakeRollers {
@@ -67,9 +68,9 @@ public class IntakeRollers {
     rollerMotor.getConfigurator().apply(slot0Configs);
   }
 
-  public void tune(double kP, double kD, double kV, double kG) {
+  public void tune(double kP, double kD, double kV, double kG, double rollerTargetVelocity) {
     setPID(kP, kD, kV, kG);
-    
+    setVelocity(rollerTargetVelocity);
   }
 
   @Logged(name = "rollerVelocity")

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
@@ -61,6 +61,7 @@ public class IntakeRollers {
 
   public void tune(double kP, double kD, double kV, double kG) {
     setPID(kP, kD, kV, kG);
+    
   }
 
   @Logged(name = "rollerVelocity")

--- a/src/main/java/frc/robot/subsystems/intakerollers/rolllercommands/IntakeRollerTune.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/rolllercommands/IntakeRollerTune.java
@@ -11,13 +11,15 @@ public class IntakeRollerTune extends Command {
   TunableConstant kD = new TunableConstant("IntakeRollers/kD", 0);
   TunableConstant kG = new TunableConstant("IntakeRollers/kG", 0);
   TunableConstant kV = new TunableConstant("IntakeRollers/kV", 0);
+  TunableConstant rollerTargetVelocity =
+      new TunableConstant("IntakeRollers/rollerTargetVelocity", 0);
 
   public IntakeRollerTune(IntakeRollers intakeRollers) {
     this.intakeRollers = intakeRollers;
   }
 
   public void execute() {
-    intakeRollers.tune(kP.get(), kD.get(), kV.get(), kG.get());
+    intakeRollers.tune(kP.get(), kD.get(), kV.get(), kG.get(), rollerTargetVelocity.get());
   }
 
   public boolean isFinished() {

--- a/src/main/java/frc/robot/subsystems/intakerollers/rolllercommands/IntakeRollerTune.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/rolllercommands/IntakeRollerTune.java
@@ -3,16 +3,21 @@ package frc.robot.subsystems.intakerollers.rolllercommands;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.intakerollers.IntakeRollers;
+import frc.robot.util.TunableConstant;
 
 public class IntakeRollerTune extends Command {
   IntakeRollers intakeRollers;
+  TunableConstant kP = new TunableConstant("IntakeRollers/kP", 0);
+  TunableConstant kD = new TunableConstant("IntakeRollers/kD", 0);
+  TunableConstant kG = new TunableConstant("IntakeRollers/kG", 0);
+  TunableConstant kV = new TunableConstant("IntakeRollers/kV", 0);
 
   public IntakeRollerTune(IntakeRollers intakeRollers) {
     this.intakeRollers = intakeRollers;
   }
 
   public void execute() {
-    intakeRollers.tune();
+    intakeRollers.tune(kP.get(), kD.get(), kV.get(), kG.get());
   }
 
   public boolean isFinished() {

--- a/src/main/java/frc/robot/subsystems/outtake/OuttakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/outtake/OuttakeConstants.java
@@ -9,6 +9,12 @@ import edu.wpi.first.units.measure.AngularVelocity;
 
 public class OuttakeConstants {
 
+  public static final double kP = 0;
+
+  public static final double kD = 0;
+
+  public static final double kV = 0;
+
   public static final int kMotorID = 0;
 
   public static final double kStatorLimit = 40;

--- a/src/main/java/frc/robot/subsystems/outtake/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/outtake/Shooter.java
@@ -21,25 +21,18 @@ import edu.wpi.first.units.measure.Velocity;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.util.TunableConstant;
 
 @Logged
 public class Shooter extends SubsystemBase {
 
   private TalonFX motor = new TalonFX(OuttakeConstants.kMotorID);
 
-  public double kP = 0;
-
-  public double kD = 0;
-
-  public double kV = 0;
-
   private Velocity targetShooterVelocity;
 
   public Shooter() {
 
     configureMotors();
-    setPID();
+    setPID(OuttakeConstants.kP, OuttakeConstants.kD, OuttakeConstants.kV);
   }
 
   private void configureMotors() {
@@ -71,7 +64,7 @@ public class Shooter extends SubsystemBase {
     motor.getConfigurator().apply(configuration);
   }
 
-  private void setPID() {
+  private void setPID(double kP, double kD, double kV) {
 
     Slot0Configs pid = new Slot0Configs().withKP(kP).withKD(kD).withKV(kV);
 
@@ -86,18 +79,9 @@ public class Shooter extends SubsystemBase {
     return run(() -> motor.setVoltage(volts.in(Volts)));
   }
 
-  public Command tune() {
-
-    TunableConstant kP = new TunableConstant("/Outtake/kP", 0);
-    TunableConstant kD = new TunableConstant("/Outtake/kD", 0);
-    TunableConstant kV = new TunableConstant("/Outtake/kV", 0);
-    TunableConstant targetRPM = new TunableConstant("/Outtake/targetRPM", 0);
-
-    this.kP = kP.get();
-    this.kD = kD.get();
-    this.kV = kV.get();
-
-    return run(() -> setControl(RPM.of(targetRPM.get())));
+  public void tune(double kP, double kD, double kV, double targetRPM) {
+    setPID(kP, kD, kV);
+    motor.setControl(new MotionMagicVelocityVoltage(RPM.of(targetRPM)));
   }
 
   @Logged

--- a/src/main/java/frc/robot/subsystems/outtake/commands/TuneOuttake.java
+++ b/src/main/java/frc/robot/subsystems/outtake/commands/TuneOuttake.java
@@ -3,10 +3,20 @@ package frc.robot.subsystems.outtake.commands;
 
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.outtake.Shooter;
+import frc.robot.util.TunableConstant;
 
-public class TuneOuttake {
+public class TuneOuttake extends Command {
+  Shooter outtake;
+  TunableConstant kP = new TunableConstant("/Outtake/kP", 0);
+  TunableConstant kD = new TunableConstant("/Outtake/kD", 0);
+  TunableConstant kV = new TunableConstant("/Outtake/kV", 0);
+  TunableConstant targetRPM = new TunableConstant("/Outtake/targetRPM", 0);
 
-  public static Command tune(Shooter outtake) {
-    return outtake.tune();
+  public TuneOuttake(Shooter outtake) {
+    this.outtake = outtake;
+  }
+
+  public void execute() {
+    outtake.tune(kP.get(), kD.get(), kV.get(), targetRPM.get());
   }
 }

--- a/src/main/java/frc/robot/subsystems/tunnel/Tunnel.java
+++ b/src/main/java/frc/robot/subsystems/tunnel/Tunnel.java
@@ -17,9 +17,10 @@ import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 @Logged
-public class Tunnel {
+public class Tunnel extends SubsystemBase {
 
   PIDController tunnelController = new PIDController(TunnelConstants.kP, 0, 0);
 

--- a/src/main/java/frc/robot/subsystems/tunnel/Tunnel.java
+++ b/src/main/java/frc/robot/subsystems/tunnel/Tunnel.java
@@ -17,7 +17,6 @@ import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Voltage;
-import frc.robot.util.TunableConstant;
 
 @Logged
 public class Tunnel {
@@ -84,19 +83,12 @@ public class Tunnel {
     tunnelController.setPID(kP, kI, kD);
   }
 
-  public void tuneTunnel() {
-    TunableConstant kP = new TunableConstant("/Tunnel/kP", 0);
+  public void tuneTunnel(double kP, double kD, double kV, double targetVelocity) {
 
-    TunableConstant kD = new TunableConstant("/Tunnel/kD", 0);
+    tunnelController.setPID(kP, 0, kD);
 
-    TunableConstant kV = new TunableConstant("/Tunnel/kV", 0);
+    tunnelFeedforward.setKv(kV);
 
-    TunableConstant targetVelocity = new TunableConstant("/Tunnel/targetVelocity", 0);
-
-    tunnelController.setPID(kP.get(), 0, kD.get());
-
-    tunnelFeedforward.setKv(kV.get());
-
-    runAtVelocity(RPM.of(targetVelocity.get()));
+    runAtVelocity(RPM.of(targetVelocity));
   }
 }

--- a/src/main/java/frc/robot/subsystems/tunnel/tunnelCommands/TuneTunnel.java
+++ b/src/main/java/frc/robot/subsystems/tunnel/tunnelCommands/TuneTunnel.java
@@ -2,16 +2,25 @@
 package frc.robot.subsystems.tunnel.tunnelCommands;
 
 import frc.robot.subsystems.tunnel.Tunnel;
+import frc.robot.util.TunableConstant;
 
 public class TuneTunnel {
 
   Tunnel tunnel;
+
+  TunableConstant kP = new TunableConstant("/Tunnel/kP", 0);
+
+  TunableConstant kD = new TunableConstant("/Tunnel/kD", 0);
+
+  TunableConstant kV = new TunableConstant("/Tunnel/kV", 0);
+
+  TunableConstant targetVelocity = new TunableConstant("/Tunnel/targetVelocity", 0);
 
   public TuneTunnel(Tunnel tunnel) {
     this.tunnel = tunnel;
   }
 
   public void execute() {
-    tunnel.tuneTunnel();
+    tunnel.tuneTunnel(kP.get(), kD.get(), kV.get(), targetVelocity.get());
   }
 }

--- a/src/main/java/frc/robot/subsystems/tunnel/tunnelCommands/TuneTunnel.java
+++ b/src/main/java/frc/robot/subsystems/tunnel/tunnelCommands/TuneTunnel.java
@@ -1,10 +1,11 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.tunnel.tunnelCommands;
 
+import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.tunnel.Tunnel;
 import frc.robot.util.TunableConstant;
 
-public class TuneTunnel {
+public class TuneTunnel extends Command {
 
   Tunnel tunnel;
 


### PR DESCRIPTION
Rewrote tuning commands such that tunable constants would be instantiated in the command file rather than the method. Also made commands that used run(() -> ) require a subsystem to be run.