### PR TITLE
R26-297 Apply current limits

### DIFF
--- a/src/main/java/frc/robot/subsystems/climb/ClimbConstants.java
+++ b/src/main/java/frc/robot/subsystems/climb/ClimbConstants.java
@@ -1,6 +1,7 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.climb;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
@@ -11,6 +12,7 @@ import com.ctre.phoenix6.signals.StaticFeedforwardSignValue;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
 
 public class ClimbConstants {
 
@@ -36,13 +38,13 @@ public class ClimbConstants {
 
   public static final int kEncoderId = 0;
 
-  public static final double kClimbStatorLimit = 1;
+  public static final Current kClimbStatorLimit = Amps.of(40);
 
-  public static final double kClimbSupplyLimit = 1;
+  public static final Current kClimbSupplyLimit = Amps.of(40);
 
-  public static final double kPivotClimbStatorLimit = 1;
+  public static final Current kPivotClimbStatorLimit = Amps.of(40);
 
-  public static final double kPivotClimbSupplyLimit = 1;
+  public static final Current kPivotClimbSupplyLimit = Amps.of(40);
 
   public static final NeutralModeValue kClimbNeutralMode = NeutralModeValue.Brake;
 

--- a/src/main/java/frc/robot/subsystems/hood/Hood.java
+++ b/src/main/java/frc/robot/subsystems/hood/Hood.java
@@ -21,6 +21,7 @@ import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.subsystems.indexer.IndexerConstants;
 
 @Logged
 public class Hood extends SubsystemBase {
@@ -42,8 +43,10 @@ public class Hood extends SubsystemBase {
         new TalonFXConfiguration()
             .withCurrentLimits(
                 new CurrentLimitsConfigs()
-                    .withStatorCurrentLimit(HoodConstants.kHoodMotorCurrentLimit)
-                    .withStatorCurrentLimitEnable(true))
+                    .withStatorCurrentLimit(HoodConstants.kHoodStatorCurrentLimit)
+                    .withStatorCurrentLimitEnable(true)
+                    .withSupplyCurrentLimit(HoodConstants.kHoodSupplyCurrentLimit)
+                    .withSupplyCurrentLimitEnable(true))
             .withMotorOutput(
                 new MotorOutputConfigs()
                     .withInverted(

--- a/src/main/java/frc/robot/subsystems/hood/Hood.java
+++ b/src/main/java/frc/robot/subsystems/hood/Hood.java
@@ -21,7 +21,6 @@ import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
-import frc.robot.subsystems.indexer.IndexerConstants;
 
 @Logged
 public class Hood extends SubsystemBase {

--- a/src/main/java/frc/robot/subsystems/hood/HoodConstants.java
+++ b/src/main/java/frc/robot/subsystems/hood/HoodConstants.java
@@ -23,7 +23,9 @@ public class HoodConstants {
 
   public static final boolean kHoodMotorInverted = false;
 
-  public static final Current kHoodMotorCurrentLimit = Amps.of(6);
+  public static final Current kHoodStatorCurrentLimit = Amps.of(40);
+
+  public static final Current kHoodSupplyCurrentLimit = Amps.of(40);
 
   public static final LinearVelocity kHoodMotorMaxVelocity = MetersPerSecond.of(1);
 

--- a/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
@@ -9,7 +9,6 @@ import edu.wpi.first.units.measure.Current;
 
 public class IntakeConstants {
   public static final int kPivotMotorId = 0;
-  public static final Current kCurrentLimits = Amps.of(40);
   public static final Current kCurrentLimit = Amps.of(40);
   public static final boolean kCurrentLimitEnable = true;
   public static final boolean kInverted = true;

--- a/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
@@ -1,14 +1,16 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.intakePivot;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
 
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.Current;
 
 public class IntakeConstants {
   public static final int kPivotMotorId = 0;
-  public static final double kCurrentLimits = 0;
-  public static final double kCurrentLimit = 0;
+  public static final Current kCurrentLimits = Amps.of(40);
+  public static final Current kCurrentLimit = Amps.of(40);
   public static final boolean kCurrentLimitEnable = true;
   public static final boolean kInverted = true;
   public static double kG = 0;

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollerConstants.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollerConstants.java
@@ -1,10 +1,16 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.intakerollers;
 
+import static edu.wpi.first.units.Units.Amps;
+
+import edu.wpi.first.units.measure.Current;
+
 public class IntakeRollerConstants {
   public static final int kRollerMotorId = 0;
-  public static final boolean kCurrentLimitsEnable = true;
-  public static final double kCurrentLimit = 0;
+  public static final boolean kStatorCurrentLimitsEnable = true;
+  public static final boolean kSupplyCurrentLimitsEnable = true;
+  public static final Current kStatorCurrentLimit = Amps.of(40);
+  public static final Current kSupplyCurrentLimit = Amps.of(40);
   public static final double kSensorToMechanismRatio = 0;
   public static final double kIntakeFuelVelocity = 0;
   public static final double kOuttakeFuelVelocity = 0;

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
@@ -44,8 +44,10 @@ public class IntakeRollers extends SubsystemBase {
     motorConfigs.withNeutralMode(NeutralModeValue.Brake);
     feedbackConfigs.withSensorToMechanismRatio(IntakeRollerConstants.kSensorToMechanismRatio);
 
-    currentLimitsConfigs.withStatorCurrentLimitEnable(IntakeRollerConstants.kCurrentLimitsEnable);
-    currentLimitsConfigs.withStatorCurrentLimit(IntakeRollerConstants.kCurrentLimit);
+    currentLimitsConfigs.withStatorCurrentLimitEnable(IntakeRollerConstants.kStatorCurrentLimitsEnable);
+    currentLimitsConfigs.withStatorCurrentLimit(IntakeRollerConstants.kStatorCurrentLimit);
+    currentLimitsConfigs.withSupplyCurrentLimitEnable(IntakeRollerConstants.kSupplyCurrentLimitsEnable);
+    currentLimitsConfigs.withSupplyCurrentLimit(IntakeRollerConstants.kSupplyCurrentLimit);
 
     rollerMotor.getConfigurator().apply(motorConfigs);
     rollerMotor.getConfigurator().apply(currentLimitsConfigs);

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
@@ -44,9 +44,11 @@ public class IntakeRollers extends SubsystemBase {
     motorConfigs.withNeutralMode(NeutralModeValue.Brake);
     feedbackConfigs.withSensorToMechanismRatio(IntakeRollerConstants.kSensorToMechanismRatio);
 
-    currentLimitsConfigs.withStatorCurrentLimitEnable(IntakeRollerConstants.kStatorCurrentLimitsEnable);
+    currentLimitsConfigs.withStatorCurrentLimitEnable(
+        IntakeRollerConstants.kStatorCurrentLimitsEnable);
     currentLimitsConfigs.withStatorCurrentLimit(IntakeRollerConstants.kStatorCurrentLimit);
-    currentLimitsConfigs.withSupplyCurrentLimitEnable(IntakeRollerConstants.kSupplyCurrentLimitsEnable);
+    currentLimitsConfigs.withSupplyCurrentLimitEnable(
+        IntakeRollerConstants.kSupplyCurrentLimitsEnable);
     currentLimitsConfigs.withSupplyCurrentLimit(IntakeRollerConstants.kSupplyCurrentLimit);
 
     rollerMotor.getConfigurator().apply(motorConfigs);

--- a/src/main/java/frc/robot/subsystems/outtake/OuttakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/outtake/OuttakeConstants.java
@@ -1,11 +1,13 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.outtake;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
 
 public class OuttakeConstants {
 
@@ -17,7 +19,9 @@ public class OuttakeConstants {
 
   public static final int kMotorID = 0;
 
-  public static final double kStatorLimit = 40;
+  public static final Current kStatorLimit = Amps.of(40);
+
+  public static final Current kSupplyLimit = Amps.of(40);
 
   public static final boolean kInverted = false;
 

--- a/src/main/java/frc/robot/subsystems/outtake/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/outtake/Shooter.java
@@ -43,7 +43,7 @@ public class Shooter extends SubsystemBase {
                 new CurrentLimitsConfigs()
                     .withStatorCurrentLimit(OuttakeConstants.kStatorLimit)
                     .withStatorCurrentLimitEnable(true)
-                    .withSupplyCurrentLimit(OuttakeConstants.kStatorLimit)
+                    .withSupplyCurrentLimit(OuttakeConstants.kSupplyLimit)
                     .withSupplyCurrentLimitEnable(true))
             .withMotorOutput(
                 new MotorOutputConfigs()

--- a/src/main/java/frc/robot/subsystems/tunnel/TunnelConstants.java
+++ b/src/main/java/frc/robot/subsystems/tunnel/TunnelConstants.java
@@ -1,6 +1,7 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.tunnel;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 
@@ -8,6 +9,7 @@ import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
 
 @Logged
 public class TunnelConstants {
@@ -20,9 +22,9 @@ public class TunnelConstants {
 
   public static final int kTunnelMotorId = 1;
 
-  public static final int kTunnelStatorLimit = 1;
+  public static final Current kTunnelStatorLimit = Amps.of(40);
 
-  public static final int kTunnelSupplyLimit = 1;
+  public static final Current kTunnelSupplyLimit = Amps.of(40);
 
   public static final NeutralModeValue kTunnelNeutralMode = NeutralModeValue.Brake;
 


### PR DESCRIPTION
Made 40 amps as the current limits for the constants. Added supply current limit to subsystems missing that in its motor's configuration.