### PR TITLE
R26-348: Hood homing

### DIFF
--- a/src/main/java/frc/robot/subsystems/hood/Hood.java
+++ b/src/main/java/frc/robot/subsystems/hood/Hood.java
@@ -1,9 +1,12 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.hood;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.MetersPerSecondPerSecond;
+import static edu.wpi.first.units.Units.RPM;
+import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
@@ -19,6 +22,9 @@ import com.ctre.phoenix6.signals.StaticFeedforwardSignValue;
 import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.epilogue.NotLogged;
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
+import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
@@ -81,8 +87,28 @@ public class Hood extends SubsystemBase {
     return angle;
   }
 
+  public AngularVelocity getVelocity(){
+    return hoodMotor.getVelocity().getValue();
+  }
+
+  public Current getCurrent(){
+    return hoodMotor.getStatorCurrent().getValue();
+  }
+
+  public boolean isHomedVelocity(){
+    return Math.abs(getVelocity().in(RPM) - HoodConstants.kHomingVelocityFloor.in(RPM)) <= HoodConstants.kHomingVelocityTolerance;
+  }
+
+  public boolean isHomedCurrent(){
+    return getCurrent().in(Amps) >= HoodConstants.kCurrentCeiling.in(Amps);
+  }
+
   public void zeroEncoder() {
     hoodMotor.setPosition(absoluteEncoder.get());
+  }
+
+  public void runVolts(Voltage volts){
+    hoodMotor.setVoltage(volts.in(Volts));
   }
 
   public boolean atTargetAngle(Angle targetAngle) {

--- a/src/main/java/frc/robot/subsystems/hood/Hood.java
+++ b/src/main/java/frc/robot/subsystems/hood/Hood.java
@@ -87,19 +87,20 @@ public class Hood extends SubsystemBase {
     return angle;
   }
 
-  public AngularVelocity getVelocity(){
+  public AngularVelocity getVelocity() {
     return hoodMotor.getVelocity().getValue();
   }
 
-  public Current getCurrent(){
+  public Current getCurrent() {
     return hoodMotor.getStatorCurrent().getValue();
   }
 
-  public boolean isHomedVelocity(){
-    return Math.abs(getVelocity().in(RPM) - HoodConstants.kHomingVelocityFloor.in(RPM)) <= HoodConstants.kHomingVelocityTolerance;
+  public boolean isHomedVelocity() {
+    return Math.abs(getVelocity().in(RPM) - HoodConstants.kHomingVelocityFloor.in(RPM))
+        <= HoodConstants.kHomingVelocityTolerance;
   }
 
-  public boolean isHomedCurrent(){
+  public boolean isHomedCurrent() {
     return getCurrent().in(Amps) >= HoodConstants.kCurrentCeiling.in(Amps);
   }
 
@@ -107,7 +108,7 @@ public class Hood extends SubsystemBase {
     hoodMotor.setPosition(absoluteEncoder.get());
   }
 
-  public void runVolts(Voltage volts){
+  public void runVolts(Voltage volts) {
     hoodMotor.setVoltage(volts.in(Volts));
   }
 

--- a/src/main/java/frc/robot/subsystems/hood/HoodConstants.java
+++ b/src/main/java/frc/robot/subsystems/hood/HoodConstants.java
@@ -5,11 +5,15 @@ import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.MetersPerSecondPerSecond;
+import static edu.wpi.first.units.Units.RPM;
+import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.LinearAcceleration;
 import edu.wpi.first.units.measure.LinearVelocity;
+import edu.wpi.first.units.measure.Voltage;
 
 public class HoodConstants {
 
@@ -52,4 +56,12 @@ public class HoodConstants {
   public static final Angle kReleaseAngle = Degrees.of(0);
 
   public static final Angle kTravelAngle = Degrees.of(0);
+
+  public static final Voltage kHomingVoltage = Volts.of(0.5);
+
+  public static final Current kCurrentCeiling = Amps.of(20);
+
+  public static final AngularVelocity kHomingVelocityFloor = RPM.of(1);
+
+  public static final double kHomingVelocityTolerance = 2;
 }

--- a/src/main/java/frc/robot/subsystems/hood/hoodCommands/HoodCommands.java
+++ b/src/main/java/frc/robot/subsystems/hood/hoodCommands/HoodCommands.java
@@ -2,8 +2,10 @@
 package frc.robot.subsystems.hood.hoodCommands;
 
 import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
 import frc.robot.subsystems.hood.Hood;
@@ -18,6 +20,10 @@ public class HoodCommands {
             () ->
                 Math.abs(angle.get().in(Degrees) - hood.getAngle().in(Degrees))
                     <= HoodConstants.kAngleTolerance.in(Degrees));
+  }
+
+  public static Command runVolts(Hood hood, Supplier<Voltage> volts){
+    return Commands.run(()->hood.runVolts(volts.get()),hood);
   }
 
   public static Command goToScoringAngle(Hood hood) {
@@ -50,5 +56,13 @@ public class HoodCommands {
 
   public static Command goToTravelAngle(Hood hood) {
     return goToAngle(hood, () -> HoodConstants.kTravelAngle);
+  }
+
+  public static Command homeHoodVelocity(Hood hood){
+    return runVolts(hood, ()->HoodConstants.kHomingVoltage).until(()->hood.isHomedVelocity());
+  }
+
+  public static Command homeHoodCurrent(Hood hood){
+    return runVolts(hood, ()->HoodConstants.kHomingVoltage).until(()->hood.isHomedCurrent());
   }
 }

--- a/src/main/java/frc/robot/subsystems/hood/hoodCommands/HoodCommands.java
+++ b/src/main/java/frc/robot/subsystems/hood/hoodCommands/HoodCommands.java
@@ -2,7 +2,6 @@
 package frc.robot.subsystems.hood.hoodCommands;
 
 import static edu.wpi.first.units.Units.Degrees;
-import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Voltage;
@@ -22,8 +21,8 @@ public class HoodCommands {
                     <= HoodConstants.kAngleTolerance.in(Degrees));
   }
 
-  public static Command runVolts(Hood hood, Supplier<Voltage> volts){
-    return Commands.run(()->hood.runVolts(volts.get()),hood);
+  public static Command runVolts(Hood hood, Supplier<Voltage> volts) {
+    return Commands.run(() -> hood.runVolts(volts.get()), hood);
   }
 
   public static Command goToScoringAngle(Hood hood) {
@@ -58,11 +57,11 @@ public class HoodCommands {
     return goToAngle(hood, () -> HoodConstants.kTravelAngle);
   }
 
-  public static Command homeHoodVelocity(Hood hood){
-    return runVolts(hood, ()->HoodConstants.kHomingVoltage).until(()->hood.isHomedVelocity());
+  public static Command homeHoodVelocity(Hood hood) {
+    return runVolts(hood, () -> HoodConstants.kHomingVoltage).until(() -> hood.isHomedVelocity());
   }
 
-  public static Command homeHoodCurrent(Hood hood){
-    return runVolts(hood, ()->HoodConstants.kHomingVoltage).until(()->hood.isHomedCurrent());
+  public static Command homeHoodCurrent(Hood hood) {
+    return runVolts(hood, () -> HoodConstants.kHomingVoltage).until(() -> hood.isHomedCurrent());
   }
 }

--- a/src/main/java/frc/robot/subsystems/hood/hoodCommands/HoodCommands.java
+++ b/src/main/java/frc/robot/subsystems/hood/hoodCommands/HoodCommands.java
@@ -58,10 +58,14 @@ public class HoodCommands {
   }
 
   public static Command homeHoodVelocity(Hood hood) {
-    return runVolts(hood, () -> HoodConstants.kHomingVoltage).until(() -> hood.isHomedVelocity());
+    return runVolts(hood, () -> HoodConstants.kHomingVoltage)
+        .until(() -> hood.isHomedVelocity())
+        .andThen(() -> hood.zeroEncoder());
   }
 
   public static Command homeHoodCurrent(Hood hood) {
-    return runVolts(hood, () -> HoodConstants.kHomingVoltage).until(() -> hood.isHomedCurrent());
+    return runVolts(hood, () -> HoodConstants.kHomingVoltage)
+        .until(() -> hood.isHomedCurrent())
+        .andThen(() -> hood.zeroEncoder());
   }
 }


### PR DESCRIPTION
Added two homing commands to hood subsystem. Both apply a small voltage until the hood is at the hardstop, and then use either velocity or current to confirm its position. 