### PR TITLE
Implemented vision to rotate to hub while driving and score into hub

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -1,7 +1,6 @@
 /* (C) RoboLancers 2026 */
 package frc.robot;
 
-import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.MetersPerSecond;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.RadiansPerSecond;
@@ -28,11 +27,11 @@ import frc.robot.commands.ShootToHub;
 import frc.robot.subsystems.drivetrain.Drivetrain;
 import frc.robot.subsystems.drivetrain.DrivetrainConstants;
 import frc.robot.subsystems.hood.Hood;
-import frc.robot.subsystems.hood.hoodCommands.HoodCommands;
 import frc.robot.subsystems.hood.hoodCommands.SetHoodAngle;
 import frc.robot.subsystems.indexer.Indexer;
 import frc.robot.subsystems.indexer.IndexerConstants;
 import frc.robot.subsystems.indexer.indexerCommands.SetIndexerVelocity;
+import frc.robot.subsystems.indexer.indexerCommands.TuneIndexer;
 import frc.robot.subsystems.intakePivot.IntakeConstants;
 import frc.robot.subsystems.intakePivot.IntakePivot;
 import frc.robot.subsystems.intakePivot.intakePivotCommands.GoToAngle;
@@ -41,11 +40,9 @@ import frc.robot.subsystems.intakerollers.rolllercommands.IntakeDefaultVelocity;
 import frc.robot.subsystems.intakerollers.rolllercommands.IntakeFuel;
 import frc.robot.subsystems.outtake.Shooter;
 import frc.robot.subsystems.outtake.commands.SetShooterVelocity;
-import frc.robot.subsystems.outtake.commands.ShootFuel;
 import frc.robot.subsystems.tunnel.Tunnel;
 import frc.robot.subsystems.vision.Vision;
 import frc.robot.util.RebuiltUtil;
-import frc.robot.util.TunableConstant;
 
 public class RobotContainer {
 
@@ -154,28 +151,42 @@ public class RobotContainer {
   }
 
   private void configureTuningBindings() {
-    hood.setDefaultCommand(HoodCommands.runVolts(hood, () -> Volts.of(0)));
-    shooter.setDefaultCommand(Commands.run(() -> shooter.setVelocity(RPM.of(0)), shooter));
-    tunnel.setDefaultCommand(Commands.run(() -> tunnel.runAtVelocity(RPM.of(0)), tunnel));
+    // hood.setDefaultCommand(HoodCommands.runVolts(hood, () -> Volts.of(0)));
+    // shooter.setDefaultCommand(Commands.run(() -> shooter.setVelocity(RPM.of(0)), shooter));
+    // tunnel.setDefaultCommand(Commands.run(() -> tunnel.runAtVelocity(RPM.of(0)), tunnel));
 
-    TunableConstant hoodPitch = new TunableConstant("RobotContainer/hoodPitch/", 0);
-    TunableConstant shooterVelocity = new TunableConstant("RobotContainer/shooterVelocity/", 0);
-    TunableConstant tunnelVelocity = new TunableConstant("RobotContainer/tunnelVelocity", 0);
+    // TunableConstant hoodPitch = new TunableConstant("RobotContainer/hoodPitch/", 0);
+    // TunableConstant shooterVelocity = new TunableConstant("RobotContainer/shooterVelocity/", 0);
+    // TunableConstant tunnelVelocity = new TunableConstant("RobotContainer/tunnelVelocity", 0);
 
-    driver.y().onTrue(HoodCommands.homeHoodMagnetic(hood));
+    // driver.y().onTrue(HoodCommands.homeHoodMagnetic(hood));
 
-    driver
-        .rightTrigger()
-        .whileTrue(
-            HoodCommands.goToAngle(hood, () -> Degrees.of(hoodPitch.get()))
-                .alongWith(
-                    // new RunAtVelocity(tunnel, () -> RPM.of(tunnelVelocity.get()))
-                    Commands.run(() -> tunnel.runAtVelocity(RPM.of(600)), tunnel)
-                        .alongWith(
-                            ShootFuel.outtakeWithVelocity(
-                                shooter, () -> RPM.of(shooterVelocity.get())))));
+    // driver
+    //     .rightTrigger()
+    //     .whileTrue(
+    //         HoodCommands.goToAngle(hood, () -> Degrees.of(hoodPitch.get()))
+    //             .alongWith(
+    //                 // new RunAtVelocity(tunnel, () -> RPM.of(tunnelVelocity.get()))
+    //                 Commands.run(() -> tunnel.runAtVelocity(RPM.of(600)), tunnel)
+    //                     .alongWith(
+    //                         ShootFuel.outtakeWithVelocity(
+    //                             shooter, () -> RPM.of(shooterVelocity.get())))));
 
-    driver.leftTrigger().whileTrue(new ShootToHub(tunnel, shooter, hood, this::getHubDistance));
+    // driver.leftTrigger().whileTrue(new ShootToHub(tunnel, shooter, hood, this::getHubDistance));
+
+    intakeRollers.setDefaultCommand(
+        Commands.run(() -> intakeRollers.setVoltage(Volts.of(0)), intakeRollers));
+
+    intakePivot.setDefaultCommand(
+        Commands.run(() -> intakePivot.setVoltage(Volts.of(0)), intakePivot));
+
+    // driver.a().whileTrue(new Tune(intakePivot));
+
+    // driver.y().whileTrue(new HomeIntakePivot(intakePivot));
+
+    indexer.setDefaultCommand(Commands.run(() -> indexer.setVoltage(Volts.of(0)), indexer));
+
+    driver.a().whileTrue(new TuneIndexer(indexer));
   }
 
   private void configureBindings() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -35,9 +35,12 @@ import frc.robot.subsystems.indexer.indexerCommands.TuneIndexer;
 import frc.robot.subsystems.intakePivot.IntakeConstants;
 import frc.robot.subsystems.intakePivot.IntakePivot;
 import frc.robot.subsystems.intakePivot.intakePivotCommands.GoToAngle;
+import frc.robot.subsystems.intakePivot.intakePivotCommands.HomeIntakePivot;
+import frc.robot.subsystems.intakePivot.intakePivotCommands.Tune;
 import frc.robot.subsystems.intakerollers.IntakeRollers;
 import frc.robot.subsystems.intakerollers.rolllercommands.IntakeDefaultVelocity;
 import frc.robot.subsystems.intakerollers.rolllercommands.IntakeFuel;
+import frc.robot.subsystems.intakerollers.rolllercommands.IntakeRollerTune;
 import frc.robot.subsystems.outtake.Shooter;
 import frc.robot.subsystems.outtake.commands.SetShooterVelocity;
 import frc.robot.subsystems.tunnel.Tunnel;
@@ -155,6 +158,19 @@ public class RobotContainer {
     // shooter.setDefaultCommand(Commands.run(() -> shooter.setVelocity(RPM.of(0)), shooter));
     // tunnel.setDefaultCommand(Commands.run(() -> tunnel.runAtVelocity(RPM.of(0)), tunnel));
 
+     drivetrain.setDefaultCommand(
+        drivetrain.teleopDrive(this::getDriverForward, this::getDriverStrafe, this::getDriverTurn));
+
+        driver
+        .leftTrigger()
+        .whileTrue(
+            Align.rotateToHubWhileDriving(
+                drivetrain,
+                this::getDriverForward,
+                this::getDriverStrafe,
+                this::getHubHeading,
+                drivetrain::getPose));
+
     // TunableConstant hoodPitch = new TunableConstant("RobotContainer/hoodPitch/", 0);
     // TunableConstant shooterVelocity = new TunableConstant("RobotContainer/shooterVelocity/", 0);
     // TunableConstant tunnelVelocity = new TunableConstant("RobotContainer/tunnelVelocity", 0);
@@ -182,13 +198,22 @@ public class RobotContainer {
 
     // driver.a().whileTrue(new Tune(intakePivot));
 
-    // driver.y().whileTrue(new HomeIntakePivot(intakePivot));
+    hood.setDefaultCommand(new SetHoodAngle(hood, hood::getTargetAngle));
+    shooter.setDefaultCommand(new SetShooterVelocity(shooter, () -> RPM.of(0)));
 
+
+
+     driver
+        .rightTrigger()
+        .whileTrue(
+            new SetIndexerVelocity(indexer, () -> IndexerConstants.kIndexVelocity)
+                .alongWith(new ShootToHub(tunnel, shooter, hood, this::getHubDistance)));
+
+    driver.y().whileTrue(new HomeIntakePivot(intakePivot));
+tunnel.setDefaultCommand(Commands.run(() -> tunnel.runAtVelocity(RPM.of(0)), tunnel));
     indexer.setDefaultCommand(Commands.run(() -> indexer.setVoltage(Volts.of(0)), indexer));
 
-    driver.y().whileTrue(Commands.run(() -> indexer.setVoltage(Volts.of(1))));
-
-    driver.a().whileTrue(new TuneIndexer(indexer));
+    driver.a().whileTrue(new Tune(intakePivot));
   }
 
   private void configureBindings() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -26,11 +26,11 @@ import frc.robot.commands.ShootToHub;
 import frc.robot.subsystems.drivetrain.Drivetrain;
 import frc.robot.subsystems.drivetrain.DrivetrainConstants;
 import frc.robot.subsystems.hood.Hood;
+import frc.robot.subsystems.hood.hoodCommands.HomeHood;
 import frc.robot.subsystems.hood.hoodCommands.SetHoodAngle;
 import frc.robot.subsystems.indexer.Indexer;
 import frc.robot.subsystems.indexer.IndexerConstants;
 import frc.robot.subsystems.indexer.indexerCommands.SetIndexerVelocity;
-import frc.robot.subsystems.indexer.indexerCommands.TuneIndexer;
 import frc.robot.subsystems.intakePivot.IntakeConstants;
 import frc.robot.subsystems.intakePivot.IntakePivot;
 import frc.robot.subsystems.intakePivot.intakePivotCommands.GoToAngle;
@@ -39,7 +39,6 @@ import frc.robot.subsystems.intakePivot.intakePivotCommands.Tune;
 import frc.robot.subsystems.intakerollers.IntakeRollers;
 import frc.robot.subsystems.intakerollers.rolllercommands.IntakeDefaultVelocity;
 import frc.robot.subsystems.intakerollers.rolllercommands.IntakeFuel;
-import frc.robot.subsystems.intakerollers.rolllercommands.IntakeRollerTune;
 import frc.robot.subsystems.outtake.Shooter;
 import frc.robot.subsystems.outtake.commands.SetShooterVelocity;
 import frc.robot.subsystems.tunnel.Tunnel;
@@ -148,10 +147,10 @@ public class RobotContainer {
     // shooter.setDefaultCommand(Commands.run(() -> shooter.setVelocity(RPM.of(0)), shooter));
     // tunnel.setDefaultCommand(Commands.run(() -> tunnel.runAtVelocity(RPM.of(0)), tunnel));
 
-     drivetrain.setDefaultCommand(
+    drivetrain.setDefaultCommand(
         drivetrain.teleopDrive(this::getDriverForward, this::getDriverStrafe, this::getDriverTurn));
 
-        driver
+    driver
         .leftTrigger()
         .whileTrue(
             Align.rotateToHubWhileDriving(
@@ -191,19 +190,19 @@ public class RobotContainer {
     hood.setDefaultCommand(new SetHoodAngle(hood, hood::getTargetAngle));
     shooter.setDefaultCommand(new SetShooterVelocity(shooter, () -> RPM.of(0)));
 
-
-
-     driver
+    driver
         .rightTrigger()
         .whileTrue(
-            new SetIndexerVelocity(indexer, () -> IndexerConstants.kIndexVelocity)
-                .alongWith(new ShootToHub(tunnel, shooter, hood, this::getHubDistance)));
+            
+                (new ShootToHub(tunnel, shooter, hood, this::getHubDistance)));
 
-    driver.y().whileTrue(new HomeIntakePivot(intakePivot));
-tunnel.setDefaultCommand(Commands.run(() -> tunnel.runAtVelocity(RPM.of(0)), tunnel));
+    driver.y().whileTrue(new HomeHood(hood));
+    tunnel.setDefaultCommand(Commands.run(() -> tunnel.runAtVelocity(RPM.of(0)), tunnel));
     indexer.setDefaultCommand(Commands.run(() -> indexer.setVoltage(Volts.of(0)), indexer));
 
     driver.a().whileTrue(new Tune(intakePivot));
+
+    driver.x().whileTrue(new SetIndexerVelocity(indexer, () -> IndexerConstants.kIndexVelocity));
   }
 
   private void configureBindings() {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -186,6 +186,8 @@ public class RobotContainer {
 
     indexer.setDefaultCommand(Commands.run(() -> indexer.setVoltage(Volts.of(0)), indexer));
 
+    driver.y().whileTrue(Commands.run(() -> indexer.setVoltage(Volts.of(1))));
+
     driver.a().whileTrue(new TuneIndexer(indexer));
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -34,7 +34,6 @@ import frc.robot.subsystems.indexer.indexerCommands.SetIndexerVelocity;
 import frc.robot.subsystems.intakePivot.IntakeConstants;
 import frc.robot.subsystems.intakePivot.IntakePivot;
 import frc.robot.subsystems.intakePivot.intakePivotCommands.GoToAngle;
-import frc.robot.subsystems.intakePivot.intakePivotCommands.HomeIntakePivot;
 import frc.robot.subsystems.intakePivot.intakePivotCommands.Tune;
 import frc.robot.subsystems.intakerollers.IntakeRollers;
 import frc.robot.subsystems.intakerollers.rolllercommands.IntakeDefaultVelocity;
@@ -190,11 +189,7 @@ public class RobotContainer {
     hood.setDefaultCommand(new SetHoodAngle(hood, hood::getTargetAngle));
     shooter.setDefaultCommand(new SetShooterVelocity(shooter, () -> RPM.of(0)));
 
-    driver
-        .rightTrigger()
-        .whileTrue(
-            
-                (new ShootToHub(tunnel, shooter, hood, this::getHubDistance)));
+    driver.rightTrigger().whileTrue((new ShootToHub(tunnel, shooter, hood, this::getHubDistance)));
 
     driver.y().whileTrue(new HomeHood(hood));
     tunnel.setDefaultCommand(Commands.run(() -> tunnel.runAtVelocity(RPM.of(0)), tunnel));

--- a/src/main/java/frc/robot/commands/Align.java
+++ b/src/main/java/frc/robot/commands/Align.java
@@ -47,7 +47,7 @@ public final class Align {
   private static final Transform2d troughAlign =
       new Transform2d(Meters.zero(), Meters.zero(), Rotation2d.kZero);
 
-  private static final Angle shooterFaceOffset = Degrees.of(0);
+  private static final Angle shooterFaceOffset = Degrees.of(90);
 
   public Command driveToPose(
       Drivetrain drivetrain, Supplier<Pose2d> pose, Supplier<Pose2d> robotPose) {
@@ -105,7 +105,7 @@ public final class Align {
 
   public static Command rotateToHub(
       Drivetrain drivetrain, Supplier<Rotation2d> hubHeading, Supplier<Pose2d> robotPose) {
-    return rotateToHubWhileDriving(drivetrain, () -> 0, () -> 0, hubHeading, robotPose);
+    return rotateToHubWhileDriving(drivetrain, () -> 0, () -> 0, ()-> new Rotation2d(Degrees.of(hubHeading.get().getDegrees()+shooterFaceOffset.in(Degrees))), robotPose);
   }
 
   public static Command rotateToHubWhileDriving(
@@ -114,7 +114,7 @@ public final class Align {
       DoubleSupplier translationY,
       Supplier<Rotation2d> hubHeading,
       Supplier<Pose2d> robotPose) {
-    return drivetrain.driveFixedHeading(translationX, translationY, hubHeading);
+    return drivetrain.driveFixedHeading(translationX, translationY, ()-> new Rotation2d(Degrees.of(hubHeading.get().getDegrees()+shooterFaceOffset.in(Degrees))));
   }
 
   public static Command alignLeftClimb(Drivetrain drivetrain, Supplier<Pose2d> robotPose) {

--- a/src/main/java/frc/robot/commands/Align.java
+++ b/src/main/java/frc/robot/commands/Align.java
@@ -105,7 +105,14 @@ public final class Align {
 
   public static Command rotateToHub(
       Drivetrain drivetrain, Supplier<Rotation2d> hubHeading, Supplier<Pose2d> robotPose) {
-    return rotateToHubWhileDriving(drivetrain, () -> 0, () -> 0, ()-> new Rotation2d(Degrees.of(hubHeading.get().getDegrees()+shooterFaceOffset.in(Degrees))), robotPose);
+    return rotateToHubWhileDriving(
+        drivetrain,
+        () -> 0,
+        () -> 0,
+        () ->
+            new Rotation2d(
+                Degrees.of(hubHeading.get().getDegrees() + shooterFaceOffset.in(Degrees))),
+        robotPose);
   }
 
   public static Command rotateToHubWhileDriving(
@@ -114,7 +121,12 @@ public final class Align {
       DoubleSupplier translationY,
       Supplier<Rotation2d> hubHeading,
       Supplier<Pose2d> robotPose) {
-    return drivetrain.driveFixedHeading(translationX, translationY, ()-> new Rotation2d(Degrees.of(hubHeading.get().getDegrees()+shooterFaceOffset.in(Degrees))));
+    return drivetrain.driveFixedHeading(
+        translationX,
+        translationY,
+        () ->
+            new Rotation2d(
+                Degrees.of(hubHeading.get().getDegrees() + shooterFaceOffset.in(Degrees))));
   }
 
   public static Command alignLeftClimb(Drivetrain drivetrain, Supplier<Pose2d> robotPose) {

--- a/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
@@ -2,6 +2,7 @@
 package frc.robot.subsystems.drivetrain;
 
 import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.Radians;
@@ -527,5 +528,7 @@ public class Drivetrain extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder> imp
     logSwerveMotorStates();
     poseField.setRobotPose(getPose());
     SmartDashboard.putData("Robot Pose Field", poseField);
+
+    SmartDashboard.putNumber("hub distance", RebuiltUtil.getHubDistance(()->getPose()).in(Inches));
   }
 }

--- a/src/main/java/frc/robot/subsystems/drivetrain/TunerConstants.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/TunerConstants.java
@@ -20,9 +20,9 @@ public class TunerConstants {
   // output type specified by SwerveModuleConstants.SteerMotorClosedLoopOutput
   private static final Slot0Configs steerGains =
       new Slot0Configs()
-          .withKP(0.01) // 75
+          .withKP(75) // 75
           .withKI(0)
-          .withKD(0) // 0.2
+          .withKD(0.2) // 0.2
           .withKS(0)
           .withKV(0)
           .withKA(0)
@@ -31,11 +31,11 @@ public class TunerConstants {
   // output type specified by SwerveModuleConstants.DriveMotorClosedLoopOutput
   private static final Slot0Configs driveGains =
       new Slot0Configs()
-          .withKP(0.13)
+          .withKP(0.321)
           .withKI(0)
           .withKD(0.0)
-          .withKS(0)
-          .withKV(0.16); // 0.321, 0.1, 0.11
+          .withKS(0.1)
+          .withKV(0.11); // 0.321, 0.1, 0.11
 
   // The closed-loop output type to use for the steer motors;
   // This affects the PID/FF gains for the steer motors

--- a/src/main/java/frc/robot/subsystems/indexer/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/Indexer.java
@@ -19,6 +19,7 @@ import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class Indexer extends SubsystemBase {
@@ -45,8 +46,8 @@ public class Indexer extends SubsystemBase {
                     .withNeutralMode(NeutralModeValue.Brake)
                     .withInverted(
                         IndexerConstants.kInverted
-                            ? InvertedValue.CounterClockwise_Positive
-                            : InvertedValue.Clockwise_Positive))
+                            ? InvertedValue.Clockwise_Positive
+                            : InvertedValue.CounterClockwise_Positive))
             .withFeedback(
                 new FeedbackConfigs().withSensorToMechanismRatio(IndexerConstants.kGearing))
             .withMotionMagic(
@@ -95,5 +96,10 @@ public class Indexer extends SubsystemBase {
   @Logged(name = "indexerCurrent")
   public Current getIndexerCurrent() {
     return motor.getStatorCurrent().getValue();
+  }
+
+  public void periodic() {
+    SmartDashboard.putNumber("Spindexer Velocity", getVelocity().in(RPM));
+    SmartDashboard.putNumber("Spindexer Voltage", getVoltage().in(Volts));
   }
 }

--- a/src/main/java/frc/robot/subsystems/indexer/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/Indexer.java
@@ -52,8 +52,7 @@ public class Indexer extends SubsystemBase {
                             ? InvertedValue.Clockwise_Positive
                             : InvertedValue.CounterClockwise_Positive))
             .withFeedback(
-                new FeedbackConfigs()
-                    .withSensorToMechanismRatio(IndexerConstants.kGearing))
+                new FeedbackConfigs().withSensorToMechanismRatio(IndexerConstants.kGearing))
             .withMotionMagic(
                 new MotionMagicConfigs()
                     .withMotionMagicCruiseVelocity(IndexerConstants.kMaxVelocity)
@@ -119,6 +118,7 @@ public class Indexer extends SubsystemBase {
   public void periodic() {
     SmartDashboard.putNumber("Spindexer Velocity", motor.getVelocity().getValue().in(RPM));
     SmartDashboard.putNumber("Spindexer Voltage", motor.getMotorVoltage().getValue().in(Volts));
-    SmartDashboard.putNumber("Spindexer motor velocity", motor.getRotorVelocity().getValue().in(RPM));
+    SmartDashboard.putNumber(
+        "Spindexer motor velocity", motor.getRotorVelocity().getValue().in(RPM));
   }
 }

--- a/src/main/java/frc/robot/subsystems/indexer/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/Indexer.java
@@ -28,7 +28,7 @@ public class Indexer extends SubsystemBase {
   private AngularVelocity targetVelocity = DegreesPerSecond.of(0);
 
   private PIDController indexerController = new PIDController(0, 0, 0);
-  private SimpleMotorFeedforward indexerFeedforward = new SimpleMotorFeedforward(0, 0);
+  private SimpleMotorFeedforward indexerFeedforward = new SimpleMotorFeedforward(0.50, 0.00795);
 
   public Indexer() {
     configureMotors();

--- a/src/main/java/frc/robot/subsystems/indexer/Indexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/Indexer.java
@@ -9,13 +9,13 @@ import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.FeedbackConfigs;
 import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.MotorOutputConfigs;
-import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
-import com.ctre.phoenix6.controls.MotionMagicVelocityVoltage;
 import com.ctre.phoenix6.hardware.TalonFX;
 import com.ctre.phoenix6.signals.InvertedValue;
 import com.ctre.phoenix6.signals.NeutralModeValue;
 import edu.wpi.first.epilogue.Logged;
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.controller.SimpleMotorFeedforward;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
@@ -27,9 +27,12 @@ public class Indexer extends SubsystemBase {
   @Logged private TalonFX motor = new TalonFX(IndexerConstants.kMotorID);
   private AngularVelocity targetVelocity = DegreesPerSecond.of(0);
 
+  private PIDController indexerController = new PIDController(0, 0, 0);
+  private SimpleMotorFeedforward indexerFeedforward = new SimpleMotorFeedforward(0, 0);
+
   public Indexer() {
     configureMotors();
-    setPID(IndexerConstants.kP, IndexerConstants.kD, IndexerConstants.kV);
+    setPID(IndexerConstants.kP, IndexerConstants.kD, IndexerConstants.kV, IndexerConstants.kS);
   }
 
   public void configureMotors() {
@@ -49,7 +52,8 @@ public class Indexer extends SubsystemBase {
                             ? InvertedValue.Clockwise_Positive
                             : InvertedValue.CounterClockwise_Positive))
             .withFeedback(
-                new FeedbackConfigs().withSensorToMechanismRatio(IndexerConstants.kGearing))
+                new FeedbackConfigs()
+                    .withSensorToMechanismRatio(IndexerConstants.kGearing))
             .withMotionMagic(
                 new MotionMagicConfigs()
                     .withMotionMagicCruiseVelocity(IndexerConstants.kMaxVelocity)
@@ -58,24 +62,38 @@ public class Indexer extends SubsystemBase {
     motor.getConfigurator().apply(configurations);
   }
 
-  public void setPID(double kP, double kD, double kV) {
-    Slot0Configs pidConfigs = new Slot0Configs().withKP(kP).withKD(kD).withKV(kV);
+  public void setPID(double kP, double kD, double kV, double kS) {
+    // Slot0Configs pidConfigs = new Slot0Configs().withKP(kP).withKD(kD).withKV(kV);
 
-    motor.getConfigurator().apply(pidConfigs);
+    // motor.getConfigurator().apply(pidConfigs);
+
+    indexerController.setP(kP);
+
+    indexerController.setD(kD);
+
+    indexerFeedforward.setKv(kV);
+
+    indexerFeedforward.setKs(kS);
   }
 
   public void goToVelocity(AngularVelocity targetVelocity) {
     this.targetVelocity = targetVelocity;
-    motor.setControl(new MotionMagicVelocityVoltage(targetVelocity));
+    // motor.setControl(new MotionMagicVelocityVoltage(targetVelocity));
+    double volts =
+        indexerController.calculate(getVelocity().in(RPM), targetVelocity.in(RPM))
+            + indexerFeedforward.calculateWithVelocities(
+                getVelocity().in(RPM), targetVelocity.in(RPM));
+
+    motor.setVoltage(volts);
   }
 
   public void setVoltage(Voltage volts) {
     motor.setVoltage(volts.in(Volts));
   }
 
-  public void tune(double kP, double kD, double kV, double targetSpeed) {
-    setPID(kP, kD, kV);
-    goToVelocity(RPM.of(targetSpeed));
+  public void tune(double kP, double kD, double kV, double kS, AngularVelocity targetSpeed) {
+    setPID(kP, kD, kV, kS);
+    goToVelocity(targetSpeed);
   }
 
   @Logged(name = "indexerTargetVelocity")
@@ -99,7 +117,8 @@ public class Indexer extends SubsystemBase {
   }
 
   public void periodic() {
-    SmartDashboard.putNumber("Spindexer Velocity", getVelocity().in(RPM));
-    SmartDashboard.putNumber("Spindexer Voltage", getVoltage().in(Volts));
+    SmartDashboard.putNumber("Spindexer Velocity", motor.getVelocity().getValue().in(RPM));
+    SmartDashboard.putNumber("Spindexer Voltage", motor.getMotorVoltage().getValue().in(Volts));
+    SmartDashboard.putNumber("Spindexer motor velocity", motor.getRotorVelocity().getValue().in(RPM));
   }
 }

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerConstants.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerConstants.java
@@ -9,17 +9,17 @@ import edu.wpi.first.units.measure.AngularVelocity;
 
 public class IndexerConstants {
 
-  public static int kMotorID = 0;
+  public static int kMotorID = 17;
 
   public static double kCurrentLimit = 40;
 
-  public static boolean kInverted = false;
+  public static boolean kInverted = true;
 
   public static double kGearing = 1 / 4;
 
-  public static AngularVelocity kMaxVelocity = RPM.of(1500);
+  public static AngularVelocity kMaxVelocity = RPM.of(1000);
 
-  public static AngularAcceleration kMaxAcceleration = RotationsPerSecondPerSecond.of(10);
+  public static AngularAcceleration kMaxAcceleration = RotationsPerSecondPerSecond.of(16);
 
   public static AngularVelocity kIndexVelocity = RPM.of(0);
 

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerConstants.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerConstants.java
@@ -15,7 +15,7 @@ public class IndexerConstants {
 
   public static boolean kInverted = true;
 
-  public static double kGearing = 1 / 4;
+  public static double kGearing = 4;
 
   public static AngularVelocity kMaxVelocity = RPM.of(1000);
 
@@ -27,5 +27,6 @@ public class IndexerConstants {
 
   public static double kP = 0;
   public static double kD = 0;
-  public static double kV = 0;
+  public static double kV = 0.00795;
+  public static double kS = 0.50;
 }

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerConstants.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerConstants.java
@@ -21,7 +21,7 @@ public class IndexerConstants {
 
   public static AngularAcceleration kMaxAcceleration = RotationsPerSecondPerSecond.of(16);
 
-  public static AngularVelocity kIndexVelocity = RPM.of(0);
+  public static AngularVelocity kIndexVelocity = RPM.of(500);
 
   public static AngularVelocity kReleaseVelocity = RPM.of(0);
 

--- a/src/main/java/frc/robot/subsystems/indexer/indexerCommands/SetIndexerVelocity.java
+++ b/src/main/java/frc/robot/subsystems/indexer/indexerCommands/SetIndexerVelocity.java
@@ -1,7 +1,6 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.indexer.indexerCommands;
 
-import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.units.measure.AngularVelocity;

--- a/src/main/java/frc/robot/subsystems/indexer/indexerCommands/SetIndexerVelocity.java
+++ b/src/main/java/frc/robot/subsystems/indexer/indexerCommands/SetIndexerVelocity.java
@@ -22,7 +22,7 @@ public class SetIndexerVelocity extends Command {
 
   @Override
   public void execute() {
-    indexer.goToVelocity(RPM.of(0));
+    indexer.goToVelocity(rpmSupplier.get());
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/indexer/indexerCommands/TuneIndexer.java
+++ b/src/main/java/frc/robot/subsystems/indexer/indexerCommands/TuneIndexer.java
@@ -1,6 +1,8 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.indexer.indexerCommands;
 
+import static edu.wpi.first.units.Units.RPM;
+
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.subsystems.indexer.Indexer;
 import frc.robot.util.TunableConstant;
@@ -10,6 +12,7 @@ public class TuneIndexer extends Command {
   TunableConstant kP = new TunableConstant("Indexer/kP/", 0);
   TunableConstant kD = new TunableConstant("Indexer/kD/", 0);
   TunableConstant kV = new TunableConstant("Indexer/kV/", 0);
+  TunableConstant kS = new TunableConstant("Indexer/kS/", 0);
   TunableConstant targetSpeed = new TunableConstant("Indexer/targetSpeed", 0);
 
   public TuneIndexer(Indexer indexer) {
@@ -17,7 +20,7 @@ public class TuneIndexer extends Command {
   }
 
   public void execute() {
-    indexer.tune(kP.get(), kD.get(), kV.get(), targetSpeed.get());
+    indexer.tune(kP.get(), kD.get(), kV.get(), kS.get(), RPM.of(targetSpeed.get()));
   }
 
   public boolean isFinished() {

--- a/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
@@ -26,6 +26,6 @@ public class IntakeConstants {
   public static final Angle kDefaultPosition = Degrees.of(0);
   public static final int kEncoderID = 0;
   public static final Angle kAngleTolerance = Degrees.of(0);
-  public static final Voltage kHomingVoltage = Volts.of(-0.5);
+  public static final Voltage kHomingVoltage = Volts.of(-0.25);
   public static final AngularVelocity kMaxVelocity = RotationsPerSecond.of(0.125);
 }

--- a/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/IntakeConstants.java
@@ -3,12 +3,16 @@ package frc.robot.subsystems.intakePivot;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.RotationsPerSecond;
+import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.units.measure.Angle;
+import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
+import edu.wpi.first.units.measure.Voltage;
 
 public class IntakeConstants {
-  public static final int kPivotMotorId = 0;
+  public static final int kPivotMotorId = 16;
   public static final Current kCurrentLimit = Amps.of(40);
   public static final boolean kCurrentLimitEnable = true;
   public static final boolean kInverted = true;
@@ -22,4 +26,6 @@ public class IntakeConstants {
   public static final Angle kDefaultPosition = Degrees.of(0);
   public static final int kEncoderID = 0;
   public static final Angle kAngleTolerance = Degrees.of(0);
+  public static final Voltage kHomingVoltage = Volts.of(-0.5);
+  public static final AngularVelocity kMaxVelocity = RotationsPerSecond.of(0.125);
 }

--- a/src/main/java/frc/robot/subsystems/intakePivot/IntakePivot.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/IntakePivot.java
@@ -1,11 +1,13 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.intakePivot;
 
+import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.FeedbackConfigs;
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.MotorOutputConfigs;
 import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.TalonFXConfiguration;
@@ -21,6 +23,7 @@ import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import frc.robot.RobotConstants;
 
@@ -35,6 +38,7 @@ public class IntakePivot extends SubsystemBase {
   private CurrentLimitsConfigs currentLimitsConfigs = new CurrentLimitsConfigs();
   private VoltageConfigs voltageConfigs = new VoltageConfigs();
   private Slot0Configs slot0Configs = new Slot0Configs();
+  private MotionMagicConfigs motionMagicConfigs = new MotionMagicConfigs();
 
   private Angle targetAngle = IntakeConstants.kDefaultPosition;
 
@@ -55,10 +59,13 @@ public class IntakePivot extends SubsystemBase {
 
     feedbackConfigs.withSensorToMechanismRatio(IntakeConstants.kSensorToMechanismRatio);
 
+    motionMagicConfigs.withMotionMagicCruiseVelocity(IntakeConstants.kMaxVelocity);
+
     intakePivotMotor.getConfigurator().apply(motorConfigs);
     intakePivotMotor.getConfigurator().apply(currentLimitsConfigs);
     intakePivotMotor.getConfigurator().apply(slot0Configs);
     intakePivotMotor.getConfigurator().apply(feedbackConfigs);
+    intakePivotMotor.getConfigurator().apply(motionMagicConfigs);
   }
 
   public void goToAngle(Angle angle) {
@@ -73,7 +80,7 @@ public class IntakePivot extends SubsystemBase {
 
   @Logged(name = "intakePivotAngle")
   public Angle getAngle() {
-    return Degrees.of(intakePivotMotor.getPosition().getValueAsDouble());
+    return intakePivotMotor.getPosition().getValue();
   }
 
   public void zeroEncoder() {
@@ -117,5 +124,16 @@ public class IntakePivot extends SubsystemBase {
   @Logged(name = "intakePivotCurrent")
   public Current getCurrent() {
     return intakePivotMotor.getStatorCurrent().getValue();
+  }
+
+  public boolean atHomedPosition() {
+    return false;
+  }
+
+  public void periodic() {
+
+    SmartDashboard.putNumber("Intake Pivot Angle", getAngle().in(Degrees));
+    SmartDashboard.putNumber("Intake Pivot Voltage", getVoltage().in(Volts));
+    SmartDashboard.putNumber("Intake Pivot Current", getCurrent().in(Amps));
   }
 }

--- a/src/main/java/frc/robot/subsystems/intakePivot/intakePivotCommands/HomeIntakePivot.java
+++ b/src/main/java/frc/robot/subsystems/intakePivot/intakePivotCommands/HomeIntakePivot.java
@@ -1,0 +1,33 @@
+/* (C) RoboLancers 2026 */
+package frc.robot.subsystems.intakePivot.intakePivotCommands;
+
+import static edu.wpi.first.units.Units.Volts;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.intakePivot.IntakeConstants;
+import frc.robot.subsystems.intakePivot.IntakePivot;
+
+public class HomeIntakePivot extends Command {
+
+  IntakePivot intakePivot;
+
+  public HomeIntakePivot(IntakePivot intakePivot) {
+    this.intakePivot = intakePivot;
+    addRequirements(intakePivot);
+  }
+
+  @Override
+  public void execute() {
+    intakePivot.setVoltage(IntakeConstants.kHomingVoltage);
+  }
+
+  @Override
+  public boolean isFinished() {
+    return intakePivot.atHomedPosition();
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    intakePivot.setVoltage(Volts.of(0));
+  }
+}

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollerConstants.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollerConstants.java
@@ -3,12 +3,14 @@ package frc.robot.subsystems.intakerollers;
 
 import static edu.wpi.first.units.Units.Amps;
 import static edu.wpi.first.units.Units.RPM;
+import static edu.wpi.first.units.Units.RotationsPerSecondPerSecond;
 
+import edu.wpi.first.units.measure.AngularAcceleration;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 
 public class IntakeRollerConstants {
-  public static final int kRollerMotorId = 0;
+  public static final int kRollerMotorId = 15;
   public static final boolean kStatorCurrentLimitsEnable = true;
   public static final boolean kSupplyCurrentLimitsEnable = true;
   public static final Current kStatorCurrentLimit = Amps.of(40);
@@ -16,6 +18,8 @@ public class IntakeRollerConstants {
   public static final double kSensorToMechanismRatio = 0;
   public static final AngularVelocity kIntakeFuelVelocity = RPM.of(0);
   public static final AngularVelocity kOuttakeFuelVelocity = RPM.of(0);
+  public static final AngularVelocity kMaxVelocity = RPM.of(1500);
+  public static final AngularAcceleration kMaxAcceleration = RotationsPerSecondPerSecond.of(25);
   public static final double kP = 0;
   public static final double kD = 0;
   public static final double kG = 0;

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollerConstants.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollerConstants.java
@@ -24,5 +24,5 @@ public class IntakeRollerConstants {
   public static final double kD = 0;
   public static final double kG = 0;
   public static final double kV = 0;
-  public static final double kIntakeRollerGearRatio = 2 / 1;
+  public static final double kIntakeRollerGearRatio = 2;
 }

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollers.java
@@ -6,6 +6,7 @@ import static edu.wpi.first.units.Units.Volts;
 
 import com.ctre.phoenix6.configs.CurrentLimitsConfigs;
 import com.ctre.phoenix6.configs.FeedbackConfigs;
+import com.ctre.phoenix6.configs.MotionMagicConfigs;
 import com.ctre.phoenix6.configs.MotorOutputConfigs;
 import com.ctre.phoenix6.configs.Slot0Configs;
 import com.ctre.phoenix6.configs.VoltageConfigs;
@@ -17,6 +18,7 @@ import edu.wpi.first.epilogue.Logged;
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.units.measure.Current;
 import edu.wpi.first.units.measure.Voltage;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
 
 public class IntakeRollers extends SubsystemBase {
@@ -27,6 +29,7 @@ public class IntakeRollers extends SubsystemBase {
   private VoltageConfigs voltageConfigs = new VoltageConfigs();
   private FeedbackConfigs feedbackConfigs = new FeedbackConfigs();
   private Slot0Configs slot0Configs = new Slot0Configs();
+  private MotionMagicConfigs motionMagicConfigs = new MotionMagicConfigs();
 
   private AngularVelocity targetVelocity = RPM.of(0);
 
@@ -40,9 +43,9 @@ public class IntakeRollers extends SubsystemBase {
   }
 
   public void motorConfigurations() {
-    motorConfigs.withInverted(InvertedValue.Clockwise_Positive);
+    motorConfigs.withInverted(InvertedValue.CounterClockwise_Positive);
     motorConfigs.withNeutralMode(NeutralModeValue.Brake);
-    feedbackConfigs.withSensorToMechanismRatio(IntakeRollerConstants.kSensorToMechanismRatio);
+    feedbackConfigs.withSensorToMechanismRatio(IntakeRollerConstants.kIntakeRollerGearRatio);
 
     currentLimitsConfigs.withStatorCurrentLimitEnable(
         IntakeRollerConstants.kStatorCurrentLimitsEnable);
@@ -50,10 +53,14 @@ public class IntakeRollers extends SubsystemBase {
     currentLimitsConfigs.withSupplyCurrentLimitEnable(
         IntakeRollerConstants.kSupplyCurrentLimitsEnable);
     currentLimitsConfigs.withSupplyCurrentLimit(IntakeRollerConstants.kSupplyCurrentLimit);
+    motionMagicConfigs
+        .withMotionMagicCruiseVelocity(IntakeRollerConstants.kMaxVelocity)
+        .withMotionMagicAcceleration(IntakeRollerConstants.kMaxAcceleration);
 
     rollerMotor.getConfigurator().apply(motorConfigs);
     rollerMotor.getConfigurator().apply(currentLimitsConfigs);
     rollerMotor.getConfigurator().apply(feedbackConfigs);
+    rollerMotor.getConfigurator().apply(motionMagicConfigs);
   }
 
   public void setVelocity(AngularVelocity velocity) {
@@ -103,5 +110,10 @@ public class IntakeRollers extends SubsystemBase {
   @Logged(name = "intakeRollersCurrent")
   public Current getCurrent() {
     return rollerMotor.getStatorCurrent().getValue();
+  }
+
+  public void periodic() {
+    SmartDashboard.putNumber("Intake Roller Velocity", getRollerVelocity().in(RPM));
+    SmartDashboard.putNumber("Intake Roller Voltage", getVoltage().in(Volts));
   }
 }

--- a/src/main/java/frc/robot/subsystems/outtake/Shooter.java
+++ b/src/main/java/frc/robot/subsystems/outtake/Shooter.java
@@ -179,8 +179,11 @@ public class Shooter extends SubsystemBase {
         "Bottom Motor Velocity", bottomShooterMotor.getVelocity().getValue().in(RPM));
     SmartDashboard.putNumber(
         "Top Shooter Motor Voltage", topShooterMotor.getMotorVoltage().getValue().in(Volts));
-
     SmartDashboard.putNumber(
-        "Bottom  Shooter Motor Voltage", bottomShooterMotor.getMotorVoltage().getValue().in(Volts));
+        "Bottom Shooter Motor Voltage", bottomShooterMotor.getMotorVoltage().getValue().in(Volts));
+    SmartDashboard.putNumber(
+        "Top Rotor Velocity", topShooterMotor.getRotorVelocity().getValue().in(RPM));
+    SmartDashboard.putNumber(
+        "Bottom Rotor Velocity", bottomShooterMotor.getRotorVelocity().getValue().in(RPM));
   }
 }

--- a/src/main/java/frc/robot/subsystems/vision/Vision.java
+++ b/src/main/java/frc/robot/subsystems/vision/Vision.java
@@ -254,5 +254,8 @@ public class Vision extends SubsystemBase {
     SmartDashboard.putNumber("Vision Pose Y", getLatestBestPose().getY());
 
     SmartDashboard.putNumber("Vision Pose Yaw", getLatestBestPose().getRotation().getDegrees());
+
+    SmartDashboard.putBoolean("right climb cam connected", getRightClimbCameraConnected());
+    SmartDashboard.putBoolean("left shooter cam connected", getLeftShooterCameraConnected());
   }
 }

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -38,21 +38,21 @@ public class VisionConstants {
           Inches.of(-8.591),
           Inches.of(11.797),
           Inches.of(5.815),
-          new Rotation3d(Degrees.zero(), Degrees.of(20), Degrees.of(30)));
+          new Rotation3d(Degrees.of(0), Degrees.of(20), Degrees.of(30)));
 
   public static final Transform3d kLeftShooterCameraTransform =
       new Transform3d(
           Inches.of(-9.026),
           Inches.of(-11.559),
           Inches.of(6.062),
-          new Rotation3d(Degrees.zero(), Degrees.of(45), Degrees.of(-65)));
+          new Rotation3d(Degrees.of(0), Degrees.of(45), Degrees.of(15))); //-75
 
   public static final Transform3d kRightShooterCameraTransform =
       new Transform3d(
           Inches.of(-11.123),
           Inches.of(-9.808),
           Inches.of(6.084),
-          new Rotation3d(Degrees.zero(), Degrees.of(45), Degrees.of(-115)));
+          new Rotation3d(Degrees.zero(), Degrees.of(45), Degrees.of(-15))); //-105
 
   public static final Distance kAllowedFieldDistance = Meters.of(2.5);
   public static final Distance kAllowedFieldHeight = Meters.of(1.25);

--- a/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
+++ b/src/main/java/frc/robot/subsystems/vision/VisionConstants.java
@@ -45,14 +45,14 @@ public class VisionConstants {
           Inches.of(-9.026),
           Inches.of(-11.559),
           Inches.of(6.062),
-          new Rotation3d(Degrees.of(0), Degrees.of(45), Degrees.of(15))); //-75
+          new Rotation3d(Degrees.of(0), Degrees.of(45), Degrees.of(15))); // -75
 
   public static final Transform3d kRightShooterCameraTransform =
       new Transform3d(
           Inches.of(-11.123),
           Inches.of(-9.808),
           Inches.of(6.084),
-          new Rotation3d(Degrees.zero(), Degrees.of(45), Degrees.of(-15))); //-105
+          new Rotation3d(Degrees.zero(), Degrees.of(45), Degrees.of(-15))); // -105
 
   public static final Distance kAllowedFieldDistance = Meters.of(2.5);
   public static final Distance kAllowedFieldHeight = Meters.of(1.25);

--- a/src/main/java/frc/robot/util/RebuiltUtil.java
+++ b/src/main/java/frc/robot/util/RebuiltUtil.java
@@ -39,9 +39,8 @@ public class RebuiltUtil {
   }
 
   public static TunableConstant xTransform = new TunableConstant("X Transform", 0);
-   public static TunableConstant yTransform = new TunableConstant("Y Transform", 0);
-  
-  
+  public static TunableConstant yTransform = new TunableConstant("Y Transform", 0);
+
   public static Rotation2d getHubHeading(Supplier<Pose2d> robotPose) {
 
     Rotation2d rotationToHub =
@@ -50,9 +49,20 @@ public class RebuiltUtil {
                 Math.PI
                     + getHubPose().getRotation().getRadians()
                     + Math.atan(
-                        (getHubPose().getY() - (robotPose.get().plus(new Transform2d(Inches.of(-8.0), Inches.of(2.5), Rotation2d.kZero))).getY())
-                            / (getHubPose().getX() - (robotPose.get().plus(new Transform2d(Inches.of(-8.0), Inches.of(2.5), Rotation2d.kZero))).getX()))));
-                          
+                        (getHubPose().getY()
+                                - (robotPose
+                                        .get()
+                                        .plus(
+                                            new Transform2d(
+                                                Inches.of(-8.0), Inches.of(2.5), Rotation2d.kZero)))
+                                    .getY())
+                            / (getHubPose().getX()
+                                - (robotPose
+                                        .get()
+                                        .plus(
+                                            new Transform2d(
+                                                Inches.of(-8.0), Inches.of(2.5), Rotation2d.kZero)))
+                                    .getX()))));
 
     return rotationToHub;
   }

--- a/src/main/java/frc/robot/util/RebuiltUtil.java
+++ b/src/main/java/frc/robot/util/RebuiltUtil.java
@@ -2,11 +2,13 @@
 package frc.robot.util;
 
 import static edu.wpi.first.units.Units.Degrees;
+import static edu.wpi.first.units.Units.Inches;
 import static edu.wpi.first.units.Units.Meters;
 import static edu.wpi.first.units.Units.Radians;
 
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Transform2d;
 import edu.wpi.first.units.measure.Distance;
 import java.util.List;
 import java.util.function.Supplier;
@@ -36,6 +38,10 @@ public class RebuiltUtil {
     return MyAlliance.isRed() ? redHubPose : blueHubPose;
   }
 
+  public static TunableConstant xTransform = new TunableConstant("X Transform", 0);
+   public static TunableConstant yTransform = new TunableConstant("Y Transform", 0);
+  
+  
   public static Rotation2d getHubHeading(Supplier<Pose2d> robotPose) {
 
     Rotation2d rotationToHub =
@@ -44,8 +50,9 @@ public class RebuiltUtil {
                 Math.PI
                     + getHubPose().getRotation().getRadians()
                     + Math.atan(
-                        (getHubPose().getY() - robotPose.get().getY())
-                            / (getHubPose().getX() - robotPose.get().getX()))));
+                        (getHubPose().getY() - (robotPose.get().plus(new Transform2d(Inches.of(-8.0), Inches.of(2.5), Rotation2d.kZero))).getY())
+                            / (getHubPose().getX() - (robotPose.get().plus(new Transform2d(Inches.of(-8.0), Inches.of(2.5), Rotation2d.kZero))).getX()))));
+                          
 
     return rotationToHub;
   }

--- a/vendordeps/Phoenix6-26.1.1.json
+++ b/vendordeps/Phoenix6-26.1.1.json
@@ -1,7 +1,7 @@
 {
-    "fileName": "Phoenix6-26.1.0.json",
+    "fileName": "Phoenix6-26.1.1.json",
     "name": "CTRE-Phoenix (v6)",
-    "version": "26.1.0",
+    "version": "26.1.1",
     "frcYear": "2026",
     "uuid": "e995de00-2c64-4df5-8831-c1441420ff19",
     "mavenUrls": [
@@ -19,14 +19,14 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-java",
-            "version": "26.1.0"
+            "version": "26.1.1"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "api-cpp",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -40,7 +40,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -54,7 +54,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "api-cpp-sim",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -68,7 +68,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -82,7 +82,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -96,7 +96,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -110,7 +110,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -124,7 +124,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -138,7 +138,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFXS",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -152,7 +152,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -166,7 +166,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -180,7 +180,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANrange",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -194,7 +194,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANdi",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -208,7 +208,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANdle",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "isJar": false,
             "skipInvalidPlatforms": true,
             "validPlatforms": [
@@ -224,7 +224,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "wpiapi-cpp",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_Phoenix6_WPI",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -240,7 +240,7 @@
         {
             "groupId": "com.ctre.phoenix6",
             "artifactId": "tools",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_PhoenixTools",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -256,7 +256,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "wpiapi-cpp-sim",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_Phoenix6_WPISim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -272,7 +272,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "tools-sim",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_PhoenixTools_Sim",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -288,7 +288,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simTalonSRX",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimTalonSRX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -304,7 +304,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simVictorSPX",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimVictorSPX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -320,7 +320,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simPigeonIMU",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimPigeonIMU",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -336,7 +336,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFX",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimProTalonFX",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -352,7 +352,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProTalonFXS",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimProTalonFXS",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -368,7 +368,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANcoder",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimProCANcoder",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -384,7 +384,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProPigeon2",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimProPigeon2",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -400,7 +400,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANrange",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimProCANrange",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -416,7 +416,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANdi",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimProCANdi",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -432,7 +432,7 @@
         {
             "groupId": "com.ctre.phoenix6.sim",
             "artifactId": "simProCANdle",
-            "version": "26.1.0",
+            "version": "26.1.1",
             "libName": "CTRE_SimProCANdle",
             "headerClassifier": "headers",
             "sharedLibrary": true,

--- a/vendordeps/photonlib.json
+++ b/vendordeps/photonlib.json
@@ -1,7 +1,7 @@
 {
     "fileName": "photonlib.json",
     "name": "photonlib",
-    "version": "v2026.1.1-rc-4",
+    "version": "v2026.3.1",
     "uuid": "515fe07e-bfc6-11fa-b3de-0242ac130004",
     "frcYear": "2026",
     "mavenUrls": [
@@ -13,7 +13,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-cpp",
-            "version": "v2026.1.1-rc-4",
+            "version": "v2026.3.1",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -28,7 +28,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-cpp",
-            "version": "v2026.1.1-rc-4",
+            "version": "v2026.3.1",
             "libName": "photonlib",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -43,7 +43,7 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-cpp",
-            "version": "v2026.1.1-rc-4",
+            "version": "v2026.3.1",
             "libName": "photontargeting",
             "headerClassifier": "headers",
             "sharedLibrary": true,
@@ -60,12 +60,12 @@
         {
             "groupId": "org.photonvision",
             "artifactId": "photonlib-java",
-            "version": "v2026.1.1-rc-4"
+            "version": "v2026.3.1"
         },
         {
             "groupId": "org.photonvision",
             "artifactId": "photontargeting-java",
-            "version": "v2026.1.1-rc-4"
+            "version": "v2026.3.1"
         }
     ]
 }

--- a/vendordeps/playingwithfusion2026.json
+++ b/vendordeps/playingwithfusion2026.json
@@ -1,7 +1,7 @@
 {
     "fileName": "playingwithfusion2026.json",
     "name": "PlayingWithFusion",
-    "version": "2026.1.16",
+    "version": "2026.2.25",
     "uuid": "14b8ad04-24df-11ea-978f-2e728ce88125",
     "frcYear": "2026",
     "jsonUrl": "https://www.playingwithfusion.com/frc/playingwithfusion2026.json",
@@ -12,14 +12,14 @@
         {
             "groupId": "com.playingwithfusion.frc",
             "artifactId": "PlayingWithFusion-java",
-            "version": "2026.1.16"
+            "version": "2026.2.25"
         }
     ],
     "jniDependencies": [
         {
             "groupId": "com.playingwithfusion.frc",
             "artifactId": "PlayingWithFusion-driver",
-            "version": "2026.1.16",
+            "version": "2026.2.25",
             "skipInvalidPlatforms": true,
             "isJar": false,
             "validPlatforms": [
@@ -36,7 +36,7 @@
         {
             "groupId": "com.playingwithfusion.frc",
             "artifactId": "PlayingWithFusion-cpp",
-            "version": "2026.1.16",
+            "version": "2026.2.25",
             "libName": "PlayingWithFusion",
             "headerClassifier": "headers",
             "sharedLibrary": false,
@@ -53,7 +53,7 @@
         {
             "groupId": "com.playingwithfusion.frc",
             "artifactId": "PlayingWithFusion-driver",
-            "version": "2026.1.16",
+            "version": "2026.2.25",
             "libName": "PlayingWithFusionDriver",
             "headerClassifier": "headers",
             "sharedLibrary": true,


### PR DESCRIPTION
Tuned spindexer
Changed index RPM to 500 rpm
Separated index and score controls to give shooter time (~2 seconds) to rev up
Changed calculated hub heading to be based on the pose of the shooter tower and not the robot center
Robot is able to rotate to hub and score