### PR TITLE
R26-477: Controls update

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -181,22 +181,13 @@ public class RobotContainer {
     driver.y().toggleOnTrue(new GoToAngle(intakePivot, () -> IntakeConstants.kIntakePosition));
 
     driver
-        .leftTrigger()
-        .whileTrue(
-            Align.rotateToHubWhileDriving(
-                drivetrain,
-                this::getDriverForward,
-                this::getDriverStrafe,
-                this::getHubHeading,
-                drivetrain::getPose));
+        .rightTrigger()
+        .whileTrue((Align.rotateToHub(drivetrain, this::getDriverForward, this::getDriverStrafe, this::getHubHeading, drivetrain::getPose).alongWith(new HomeHood(hood))).andThen(new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance).alongWith(Align.lockOnHub(drivetrain,this::getDriverForward, this::getDriverStrafe, this::getHubHeading, drivetrain::getPose))));
 
     driver
-        .rightTrigger()
-        .whileTrue(
-            new HomeHood(hood)
-                .andThen(
-                    new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance)
-                        .alongWith(new RepeatCommand(drivetrain.jostleDrivetrain()))));
+        .leftTrigger()
+        .whileTrue((Align.rotateToHub(drivetrain, this::getDriverForward, this::getDriverStrafe, this::getHubHeading, drivetrain::getPose).alongWith(new HomeHood(hood))).andThen(new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance).alongWith(new RepeatCommand(drivetrain.jostleDrivetrain()))));
+
 
     driver
         .rightBumper()

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -194,13 +194,7 @@ public class RobotContainer {
     driver
         .rightTrigger()
         .whileTrue(
-            (Align.rotateToHub(
-                        drivetrain,
-                        this::getDriverForward,
-                        this::getDriverStrafe,
-                        this::getHubHeading,
-                        drivetrain::getPose)
-                    .alongWith(new HomeHood(hood)))
+            (new HomeHood(hood))
                 .andThen(
                     new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance)
                         .alongWith(
@@ -214,30 +208,19 @@ public class RobotContainer {
     driver
         .leftTrigger()
         .whileTrue(
-            (Align.rotateToHub(
+            Align.rotateToHub(
                         drivetrain,
                         this::getDriverForward,
                         this::getDriverStrafe,
                         this::getHubHeading,
                         drivetrain::getPose)
-                    .alongWith(new HomeHood(hood)))
-                .andThen(
-                    new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance)
-                        .alongWith(new RepeatCommand(drivetrain.jostleDrivetrain()))));
+                    .alongWith(new HomeHood(hood)));
 
     driver
         .rightBumper()
         .whileTrue(new HomeHood(hood).andThen(new Feed(tunnel, shooter, hood, indexer)));
 
     driver.a().whileTrue(new HomeHood(hood).andThen(new StaticShoot(tunnel, shooter, indexer)));
-
-    driver
-        .b()
-        .whileTrue(
-            new HomeHood(hood)
-                .andThen(
-                    new StaticShoot(tunnel, shooter, indexer)
-                        .alongWith(new RepeatCommand(drivetrain.jostleDrivetrain()))));
   }
 
   @Logged(name = "autonomousCommand")

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -119,6 +119,16 @@ public class RobotContainer {
     return RebuiltUtil.getHubHeading(drivetrain::getPose);
   }
 
+  @Logged(name = "hubAngle")
+  public double getHubAngle() {
+    return getHubHeading().getDegrees();
+  }
+
+  @Logged(name = "robotAngle")
+  public double getRobotAngle() {
+    return drivetrain.getPose().getRotation().getDegrees();
+  }
+
   @Logged(name = "calculatedHubDistance")
   public Distance getHubDistance() {
     return RebuiltUtil.getHubDistance(drivetrain::getPose);
@@ -183,24 +193,43 @@ public class RobotContainer {
 
     driver
         .rightTrigger()
-        .whileTrue((Align.rotateToHub(drivetrain, this::getDriverForward, this::getDriverStrafe, this::getHubHeading, drivetrain::getPose).alongWith(new HomeHood(hood))).andThen(new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance).alongWith(Align.lockOnHub(drivetrain,this::getDriverForward, this::getDriverStrafe, this::getHubHeading, drivetrain::getPose))));
+        .whileTrue(
+            (Align.rotateToHub(
+                        drivetrain,
+                        this::getDriverForward,
+                        this::getDriverStrafe,
+                        this::getHubHeading,
+                        drivetrain::getPose)
+                    .alongWith(new HomeHood(hood)))
+                .andThen(
+                    new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance)
+                        .alongWith(
+                            Align.lockOnHub(
+                                drivetrain,
+                                this::getDriverForward,
+                                this::getDriverStrafe,
+                                this::getHubHeading,
+                                drivetrain::getPose))));
 
     driver
         .leftTrigger()
-        .whileTrue((Align.rotateToHub(drivetrain, this::getDriverForward, this::getDriverStrafe, this::getHubHeading, drivetrain::getPose).alongWith(new HomeHood(hood))).andThen(new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance).alongWith(new RepeatCommand(drivetrain.jostleDrivetrain()))));
-
+        .whileTrue(
+            (Align.rotateToHub(
+                        drivetrain,
+                        this::getDriverForward,
+                        this::getDriverStrafe,
+                        this::getHubHeading,
+                        drivetrain::getPose)
+                    .alongWith(new HomeHood(hood)))
+                .andThen(
+                    new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance)
+                        .alongWith(new RepeatCommand(drivetrain.jostleDrivetrain()))));
 
     driver
         .rightBumper()
         .whileTrue(new HomeHood(hood).andThen(new Feed(tunnel, shooter, hood, indexer)));
 
-    driver
-        .a()
-        .whileTrue(
-            new HomeHood(hood)
-                .andThen(
-                    new StaticShoot(tunnel, shooter, indexer)
-                        ));
+    driver.a().whileTrue(new HomeHood(hood).andThen(new StaticShoot(tunnel, shooter, indexer)));
 
     driver
         .b()

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -21,7 +21,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SendableChooser;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.Commands;
-import edu.wpi.first.wpilibj2.command.RepeatCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 import frc.robot.commands.Align;
@@ -209,12 +208,12 @@ public class RobotContainer {
         .leftTrigger()
         .whileTrue(
             Align.lockOnHub(
-                        drivetrain,
-                        this::getDriverForward,
-                        this::getDriverStrafe,
-                        this::getHubHeading,
-                        drivetrain::getPose)
-                    .alongWith(new HomeHood(hood)));
+                    drivetrain,
+                    this::getDriverForward,
+                    this::getDriverStrafe,
+                    this::getHubHeading,
+                    drivetrain::getPose)
+                .alongWith(new HomeHood(hood)));
 
     driver
         .rightBumper()

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -28,6 +28,7 @@ import frc.robot.commands.Align;
 import frc.robot.commands.Feed;
 import frc.robot.commands.Release;
 import frc.robot.commands.ShootAndIndex;
+import frc.robot.commands.StaticShoot;
 import frc.robot.subsystems.drivetrain.Drivetrain;
 import frc.robot.subsystems.drivetrain.DrivetrainConstants;
 import frc.robot.subsystems.hood.Hood;
@@ -198,15 +199,15 @@ public class RobotContainer {
         .whileTrue(
             new HomeHood(hood)
                 .andThen(
-                    new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance)
-                        .alongWith(new RepeatCommand(drivetrain.jostleDrivetrain()))));
+                    new StaticShoot(tunnel, shooter, indexer)
+                        ));
 
     driver
         .b()
         .whileTrue(
             new HomeHood(hood)
                 .andThen(
-                    new Feed(tunnel, shooter, hood, indexer)
+                    new StaticShoot(tunnel, shooter, indexer)
                         .alongWith(new RepeatCommand(drivetrain.jostleDrivetrain()))));
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -208,7 +208,7 @@ public class RobotContainer {
     driver
         .leftTrigger()
         .whileTrue(
-            Align.rotateToHub(
+            Align.lockOnHub(
                         drivetrain,
                         this::getDriverForward,
                         this::getDriverStrafe,

--- a/src/main/java/frc/robot/commands/Align.java
+++ b/src/main/java/frc/robot/commands/Align.java
@@ -105,7 +105,7 @@ public final class Align {
 
   public static Command rotateToHub(
       Drivetrain drivetrain, DoubleSupplier translationX, DoubleSupplier translationY, Supplier<Rotation2d> hubHeading, Supplier<Pose2d> robotPose) {
-   return lockOnHub(drivetrain, translationX, translationY, hubHeading, robotPose).until(drivetrain.atHeading(hubHeading));
+   return lockOnHub(drivetrain, translationX, translationY, hubHeading, robotPose).until(()->drivetrain.atHeading(hubHeading.get()));
   }
 
   public static Command lockOnHub(

--- a/src/main/java/frc/robot/commands/Align.java
+++ b/src/main/java/frc/robot/commands/Align.java
@@ -103,16 +103,6 @@ public final class Align {
     return drivetrain.driveToFieldPoseCommand(() -> getHubScoringPose(robotPose), robotPose);
   }
 
-  public static Command rotateToHub(
-      Drivetrain drivetrain,
-      DoubleSupplier translationX,
-      DoubleSupplier translationY,
-      Supplier<Rotation2d> hubHeading,
-      Supplier<Pose2d> robotPose) {
-    return lockOnHub(drivetrain, translationX, translationY, hubHeading, robotPose)
-        .withTimeout(0.5);
-  }
-
   public static Command lockOnHub(
       Drivetrain drivetrain,
       DoubleSupplier translationX,

--- a/src/main/java/frc/robot/commands/Align.java
+++ b/src/main/java/frc/robot/commands/Align.java
@@ -104,18 +104,11 @@ public final class Align {
   }
 
   public static Command rotateToHub(
-      Drivetrain drivetrain, Supplier<Rotation2d> hubHeading, Supplier<Pose2d> robotPose) {
-    return rotateToHubWhileDriving(
-        drivetrain,
-        () -> 0,
-        () -> 0,
-        () ->
-            new Rotation2d(
-                Degrees.of(hubHeading.get().getDegrees() + shooterFaceOffset.in(Degrees))),
-        robotPose);
+      Drivetrain drivetrain, DoubleSupplier translationX, DoubleSupplier translationY, Supplier<Rotation2d> hubHeading, Supplier<Pose2d> robotPose) {
+   return lockOnHub(drivetrain, translationX, translationY, hubHeading, robotPose).until(drivetrain.atHeading(hubHeading));
   }
 
-  public static Command rotateToHubWhileDriving(
+  public static Command lockOnHub(
       Drivetrain drivetrain,
       DoubleSupplier translationX,
       DoubleSupplier translationY,
@@ -128,6 +121,8 @@ public final class Align {
             new Rotation2d(
                 Degrees.of(hubHeading.get().getDegrees() + shooterFaceOffset.in(Degrees))));
   }
+
+  
 
   public static Command alignLeftClimb(Drivetrain drivetrain, Supplier<Pose2d> robotPose) {
     Pose2d climbPose =

--- a/src/main/java/frc/robot/commands/Align.java
+++ b/src/main/java/frc/robot/commands/Align.java
@@ -104,8 +104,13 @@ public final class Align {
   }
 
   public static Command rotateToHub(
-      Drivetrain drivetrain, DoubleSupplier translationX, DoubleSupplier translationY, Supplier<Rotation2d> hubHeading, Supplier<Pose2d> robotPose) {
-   return lockOnHub(drivetrain, translationX, translationY, hubHeading, robotPose).until(()->drivetrain.atHeading(hubHeading.get()));
+      Drivetrain drivetrain,
+      DoubleSupplier translationX,
+      DoubleSupplier translationY,
+      Supplier<Rotation2d> hubHeading,
+      Supplier<Pose2d> robotPose) {
+    return lockOnHub(drivetrain, translationX, translationY, hubHeading, robotPose)
+        .withTimeout(0.5);
   }
 
   public static Command lockOnHub(
@@ -121,8 +126,6 @@ public final class Align {
             new Rotation2d(
                 Degrees.of(hubHeading.get().getDegrees() + shooterFaceOffset.in(Degrees))));
   }
-
-  
 
   public static Command alignLeftClimb(Drivetrain drivetrain, Supplier<Pose2d> robotPose) {
     Pose2d climbPose =

--- a/src/main/java/frc/robot/commands/StaticShoot.java
+++ b/src/main/java/frc/robot/commands/StaticShoot.java
@@ -31,7 +31,7 @@ public class StaticShoot extends Command {
     shooter.goToVelocity(OuttakeConstants.kStaticScoreRPM);
     shooter.setTargetVelocity(OuttakeConstants.kStaticScoreRPM);
 
-    if (Math.abs(shooter.getTopVelocity().in(RPM) - OuttakeConstants.kNeutralFeedRPM.in(RPM))
+    if (Math.abs(shooter.getTopVelocity().in(RPM) - OuttakeConstants.kStaticScoreRPM.in(RPM))
         < 25) {
       indexer.setTargetVelocity(indexer.getOscillationVelocity());
       tunnel.setTargetVelocity(TunnelConstants.kPassFuelRPM);

--- a/src/main/java/frc/robot/commands/StaticShoot.java
+++ b/src/main/java/frc/robot/commands/StaticShoot.java
@@ -1,0 +1,58 @@
+/* (C) RoboLancers 2026 */
+package frc.robot.commands;
+
+import static edu.wpi.first.units.Units.RPM;
+import static edu.wpi.first.units.Units.Volts;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.indexer.Indexer;
+import frc.robot.subsystems.outtake.OuttakeConstants;
+import frc.robot.subsystems.outtake.Shooter;
+import frc.robot.subsystems.tunnel.Tunnel;
+import frc.robot.subsystems.tunnel.TunnelConstants;
+
+public class StaticShoot extends Command {
+
+  Tunnel tunnel;
+  Shooter shooter;
+  Indexer indexer;
+
+  public StaticShoot(Tunnel tunnel, Shooter shooter, Indexer indexer) {
+    this.tunnel = tunnel;
+    this.shooter = shooter;
+    this.indexer = indexer;
+
+    addRequirements(tunnel, shooter, indexer);
+  }
+
+  @Override
+  public void execute() {
+
+    shooter.goToVelocity(OuttakeConstants.kStaticScoreRPM);
+    shooter.setTargetVelocity(OuttakeConstants.kStaticScoreRPM);
+
+    if (Math.abs(shooter.getTopVelocity().in(RPM) - OuttakeConstants.kNeutralFeedRPM.in(RPM))
+        < 25) {
+      indexer.setTargetVelocity(indexer.getOscillationVelocity());
+      tunnel.setTargetVelocity(TunnelConstants.kPassFuelRPM);
+      tunnel.goToVelocity(TunnelConstants.kPassFuelRPM);
+      indexer.goToVelocity(indexer.getOscillationVelocity());
+    }
+  }
+
+  @Override
+  public boolean isFinished() {
+    return false;
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    shooter.setVoltage(Volts.of(0));
+    tunnel.setVoltage(Volts.of(0));
+    indexer.setVoltage(Volts.of(0));
+
+    shooter.setTargetVelocity(RPM.of(0));
+    tunnel.setTargetVelocity(RPM.of(0));
+    indexer.setTargetVelocity(RPM.of(0));
+  }
+}

--- a/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
@@ -452,11 +452,6 @@ public class Drivetrain extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder> imp
             < rotTol.in(Degrees);
   }
 
-  public Command jostleDrivetrain() {
-    return (driveRobotCentric(() -> -1, () -> 0, () -> 0).withTimeout(0.2))
-        .andThen(driveRobotCentric(() -> 1, () -> 0, () -> 0).withTimeout(0.215));
-  }
-
   public void setSwerveModuleStates(SwerveModuleState[] states) {
     for (int i = 0; i < super.getModules().length; i++) {
       super.getModule(i).apply(new ModuleRequest().withState(states[i]));

--- a/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
@@ -463,10 +463,6 @@ public class Drivetrain extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder> imp
     }
   }
 
-  public boolean atHeading(Rotation2d heading){
-    return Math.abs(getPose().getRotation().getDegrees() - heading.getDegrees()) <= 5;
-  }
-
   @Logged(name = "MeasuredModuleStates")
   public SwerveModuleState[] getMeasuredModuleStates() {
     return super.getState().ModuleStates;

--- a/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
@@ -463,6 +463,10 @@ public class Drivetrain extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder> imp
     }
   }
 
+  public boolean atHeading(Rotation2d heading){
+    return Math.abs(getPose().getRotation().getDegrees() - heading.getDegrees()) <= 5;
+  }
+
   @Logged(name = "MeasuredModuleStates")
   public SwerveModuleState[] getMeasuredModuleStates() {
     return super.getState().ModuleStates;

--- a/src/main/java/frc/robot/subsystems/outtake/OuttakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/outtake/OuttakeConstants.java
@@ -48,6 +48,8 @@ public class OuttakeConstants {
 
   public static final AngularVelocity kMaxVelocity = RPM.of(2000);
 
+  public static final AngularVelocity kStaticScoreRPM = RPM.of(700);
+
   public static final AngularAcceleration kMaxAcceleration = RotationsPerSecondPerSecond.of(1000);
 
   public static final MotorAlignmentValue kFollowerReversed = MotorAlignmentValue.Opposed;


### PR DESCRIPTION
Added command to rotate to hub once (instead of continuously)
Updated following buttons:
Right trigger: aligns once, then shoots while aligning continuously
Left trigger: aligns once, then shoots while jostling drivetrain
a: Static shooting (constant shooter rpm and hood angle)
b: Static shooting while jostling drivetrain