### PR TITLE
R26-479: Rotate to hub

### DIFF
--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -114,6 +114,7 @@ public class Robot extends TimedRobot {
     if (m_autonomousCommand != null) {
       m_autonomousCommand.cancel();
     }
+    CommandScheduler.getInstance().schedule(new HomeHood(m_robotContainer.hood));
   }
 
   @Override

--- a/src/main/java/frc/robot/RobotConstants.java
+++ b/src/main/java/frc/robot/RobotConstants.java
@@ -16,4 +16,5 @@ public class RobotConstants {
       AprilTagFieldLayout.loadField(AprilTagFields.k2026RebuiltWelded);
 
   public static final Angle kAngleTolerance = Degrees.of(0.5);
+  public static final Angle kShooterFaceOffset = Degrees.of(90);
 }

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -128,6 +128,26 @@ public class RobotContainer {
     return drivetrain.getPose().getRotation().getDegrees();
   }
 
+  @Logged(name = "shooterAngle")
+  public double getShooterAngle() {
+    return getRobotAngle() - 90;
+  }
+
+  @Logged(name = "finalShooterAngle")
+  public double getFinalShooterAngle(){
+    return Math.floorMod(Math.round(getShooterAngle()), 360);
+  }
+
+  @Logged(name = "finalHubAngle")
+  public double getFinalHubAngle(){
+    return Math.floorMod(Math.round(getHubAngle()),360);
+  }
+
+  @Logged(name = "shooterAtHeading")
+  public boolean shooterAtHeading(){
+    return drivetrain.shooterAtHeading(getHubHeading());
+  }
+
   @Logged(name = "calculatedHubDistance")
   public Distance getHubDistance() {
     return RebuiltUtil.getHubDistance(drivetrain::getPose);
@@ -193,7 +213,7 @@ public class RobotContainer {
     driver
         .rightTrigger()
         .whileTrue(
-            (new HomeHood(hood))
+            (new HomeHood(hood).alongWith(Align.rotateToHub(drivetrain, this::getDriverForward, this::getDriverStrafe, this::getHubHeading, drivetrain::getPose)))
                 .andThen(
                     new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance)
                         .alongWith(
@@ -212,8 +232,7 @@ public class RobotContainer {
                     this::getDriverForward,
                     this::getDriverStrafe,
                     this::getHubHeading,
-                    drivetrain::getPose)
-                .alongWith(new HomeHood(hood)));
+                    drivetrain::getPose));
 
     driver
         .rightBumper()
@@ -222,7 +241,7 @@ public class RobotContainer {
     driver.a().whileTrue(new HomeHood(hood).andThen(new StaticShoot(tunnel, shooter, indexer)));
   }
 
-  @Logged(name = "autonomousCommand")
+  @Logged(name = "autonomousCommand") 
   public Command getAutonomousCommand() {
 
     return autoChooser.getSelected();

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -31,7 +31,6 @@ import frc.robot.commands.StaticShoot;
 import frc.robot.subsystems.drivetrain.Drivetrain;
 import frc.robot.subsystems.drivetrain.DrivetrainConstants;
 import frc.robot.subsystems.hood.Hood;
-import frc.robot.subsystems.hood.hoodCommands.HomeHood;
 import frc.robot.subsystems.indexer.Indexer;
 import frc.robot.subsystems.indexer.indexerCommands.SetIndexerVelocity;
 import frc.robot.subsystems.intakePivot.IntakeConstants;
@@ -213,14 +212,12 @@ public class RobotContainer {
     driver
         .rightTrigger()
         .whileTrue(
-            (new HomeHood(hood)
-                    .alongWith(
-                        Align.rotateToHub(
-                            drivetrain,
-                            this::getDriverForward,
-                            this::getDriverStrafe,
-                            this::getHubHeading,
-                            drivetrain::getPose)))
+            (Align.rotateToHub(
+                    drivetrain,
+                    this::getDriverForward,
+                    this::getDriverStrafe,
+                    this::getHubHeading,
+                    drivetrain::getPose))
                 .andThen(
                     new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance)
                         .alongWith(
@@ -241,11 +238,9 @@ public class RobotContainer {
                 this::getHubHeading,
                 drivetrain::getPose));
 
-    driver
-        .rightBumper()
-        .whileTrue(new HomeHood(hood).andThen(new Feed(tunnel, shooter, hood, indexer)));
+    driver.rightBumper().whileTrue(new Feed(tunnel, shooter, hood, indexer));
 
-    driver.a().whileTrue(new HomeHood(hood).andThen(new StaticShoot(tunnel, shooter, indexer)));
+    driver.a().whileTrue(new StaticShoot(tunnel, shooter, indexer));
   }
 
   @Logged(name = "autonomousCommand")

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -134,17 +134,17 @@ public class RobotContainer {
   }
 
   @Logged(name = "finalShooterAngle")
-  public double getFinalShooterAngle(){
+  public double getFinalShooterAngle() {
     return Math.floorMod(Math.round(getShooterAngle()), 360);
   }
 
   @Logged(name = "finalHubAngle")
-  public double getFinalHubAngle(){
-    return Math.floorMod(Math.round(getHubAngle()),360);
+  public double getFinalHubAngle() {
+    return Math.floorMod(Math.round(getHubAngle()), 360);
   }
 
   @Logged(name = "shooterAtHeading")
-  public boolean shooterAtHeading(){
+  public boolean shooterAtHeading() {
     return drivetrain.shooterAtHeading(getHubHeading());
   }
 
@@ -213,7 +213,14 @@ public class RobotContainer {
     driver
         .rightTrigger()
         .whileTrue(
-            (new HomeHood(hood).alongWith(Align.rotateToHub(drivetrain, this::getDriverForward, this::getDriverStrafe, this::getHubHeading, drivetrain::getPose)))
+            (new HomeHood(hood)
+                    .alongWith(
+                        Align.rotateToHub(
+                            drivetrain,
+                            this::getDriverForward,
+                            this::getDriverStrafe,
+                            this::getHubHeading,
+                            drivetrain::getPose)))
                 .andThen(
                     new ShootAndIndex(tunnel, shooter, hood, indexer, this::getHubDistance)
                         .alongWith(
@@ -228,11 +235,11 @@ public class RobotContainer {
         .leftTrigger()
         .whileTrue(
             Align.lockOnHub(
-                    drivetrain,
-                    this::getDriverForward,
-                    this::getDriverStrafe,
-                    this::getHubHeading,
-                    drivetrain::getPose));
+                drivetrain,
+                this::getDriverForward,
+                this::getDriverStrafe,
+                this::getHubHeading,
+                drivetrain::getPose));
 
     driver
         .rightBumper()
@@ -241,7 +248,7 @@ public class RobotContainer {
     driver.a().whileTrue(new HomeHood(hood).andThen(new StaticShoot(tunnel, shooter, indexer)));
   }
 
-  @Logged(name = "autonomousCommand") 
+  @Logged(name = "autonomousCommand")
   public Command getAutonomousCommand() {
 
     return autoChooser.getSelected();

--- a/src/main/java/frc/robot/commands/Align.java
+++ b/src/main/java/frc/robot/commands/Align.java
@@ -47,8 +47,6 @@ public final class Align {
   private static final Transform2d troughAlign =
       new Transform2d(Meters.zero(), Meters.zero(), Rotation2d.kZero);
 
-  private static final Angle shooterFaceOffset = Degrees.of(90);
-
   public Command driveToPose(
       Drivetrain drivetrain, Supplier<Pose2d> pose, Supplier<Pose2d> robotPose) {
     return drivetrain.driveToFieldPoseCommand(pose, robotPose);
@@ -103,6 +101,15 @@ public final class Align {
     return drivetrain.driveToFieldPoseCommand(() -> getHubScoringPose(robotPose), robotPose);
   }
 
+public static Command rotateToHub(
+      Drivetrain drivetrain,
+      DoubleSupplier translationX,
+      DoubleSupplier translationY,
+      Supplier<Rotation2d> hubHeading,
+      Supplier<Pose2d> robotPose) {
+    return lockOnHub(drivetrain,translationX, translationY, hubHeading, robotPose).until(()->drivetrain.shooterAtHeading(hubHeading.get()));
+  }
+
   public static Command lockOnHub(
       Drivetrain drivetrain,
       DoubleSupplier translationX,
@@ -114,7 +121,7 @@ public final class Align {
         translationY,
         () ->
             new Rotation2d(
-                Degrees.of(hubHeading.get().getDegrees() + shooterFaceOffset.in(Degrees))));
+                Degrees.of(hubHeading.get().getDegrees() + RobotConstants.kShooterFaceOffset.in(Degrees))));
   }
 
   public static Command alignLeftClimb(Drivetrain drivetrain, Supplier<Pose2d> robotPose) {

--- a/src/main/java/frc/robot/commands/Align.java
+++ b/src/main/java/frc/robot/commands/Align.java
@@ -8,7 +8,6 @@ import static edu.wpi.first.units.Units.Meters;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Transform2d;
-import edu.wpi.first.units.measure.Angle;
 import edu.wpi.first.units.measure.Distance;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.RobotConstants;
@@ -101,13 +100,14 @@ public final class Align {
     return drivetrain.driveToFieldPoseCommand(() -> getHubScoringPose(robotPose), robotPose);
   }
 
-public static Command rotateToHub(
+  public static Command rotateToHub(
       Drivetrain drivetrain,
       DoubleSupplier translationX,
       DoubleSupplier translationY,
       Supplier<Rotation2d> hubHeading,
       Supplier<Pose2d> robotPose) {
-    return lockOnHub(drivetrain,translationX, translationY, hubHeading, robotPose).until(()->drivetrain.shooterAtHeading(hubHeading.get()));
+    return lockOnHub(drivetrain, translationX, translationY, hubHeading, robotPose)
+        .until(() -> drivetrain.shooterAtHeading(hubHeading.get()));
   }
 
   public static Command lockOnHub(
@@ -121,7 +121,9 @@ public static Command rotateToHub(
         translationY,
         () ->
             new Rotation2d(
-                Degrees.of(hubHeading.get().getDegrees() + RobotConstants.kShooterFaceOffset.in(Degrees))));
+                Degrees.of(
+                    hubHeading.get().getDegrees()
+                        + RobotConstants.kShooterFaceOffset.in(Degrees))));
   }
 
   public static Command alignLeftClimb(Drivetrain drivetrain, Supplier<Pose2d> robotPose) {

--- a/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
@@ -458,8 +458,15 @@ public class Drivetrain extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder> imp
     }
   }
 
-  public boolean shooterAtHeading(Rotation2d heading){
-    return Math.abs(Math.floorMod(Math.round(getPose().getRotation().getDegrees()-RobotConstants.kShooterFaceOffset.in(Degrees)),360 ) - Math.floorMod(Math.round(heading.getDegrees()), 360)) <= DrivetrainConstants.kSpinupRange.in(Degrees);
+  public boolean shooterAtHeading(Rotation2d heading) {
+    return Math.abs(
+            Math.floorMod(
+                    Math.round(
+                        getPose().getRotation().getDegrees()
+                            - RobotConstants.kShooterFaceOffset.in(Degrees)),
+                    360)
+                - Math.floorMod(Math.round(heading.getDegrees()), 360))
+        <= DrivetrainConstants.kSpinupRange.in(Degrees);
   }
 
   @Logged(name = "MeasuredModuleStates")

--- a/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/Drivetrain.java
@@ -458,6 +458,10 @@ public class Drivetrain extends SwerveDrivetrain<TalonFX, TalonFX, CANcoder> imp
     }
   }
 
+  public boolean shooterAtHeading(Rotation2d heading){
+    return Math.abs(Math.floorMod(Math.round(getPose().getRotation().getDegrees()-RobotConstants.kShooterFaceOffset.in(Degrees)),360 ) - Math.floorMod(Math.round(heading.getDegrees()), 360)) <= DrivetrainConstants.kSpinupRange.in(Degrees);
+  }
+
   @Logged(name = "MeasuredModuleStates")
   public SwerveModuleState[] getMeasuredModuleStates() {
     return super.getState().ModuleStates;

--- a/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
+++ b/src/main/java/frc/robot/subsystems/drivetrain/DrivetrainConstants.java
@@ -56,6 +56,8 @@ public class DrivetrainConstants {
       Meters.of(0.1); // distance at which to end changing weights from velocity control to PID when
   // aligning
 
+  public static final Angle kSpinupRange = Degrees.of(20);
+
   public static final double kMaxPathVelocity = 3.0;
   public static final double kMaxPathAcceleration = 4.0;
   public static final double kMaxPathAngularVelocity = 540;


### PR DESCRIPTION
Added shooter face at heading boolean to act as end condition for one rotation to hub
Changed right trigger to first rotate to hub once and then shoot while locked on to hub