### PR TITLE
R26-486: Release fuel from rollers

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -37,6 +37,7 @@ import frc.robot.subsystems.indexer.indexerCommands.SetIndexerVelocity;
 import frc.robot.subsystems.intakePivot.IntakeConstants;
 import frc.robot.subsystems.intakePivot.IntakePivot;
 import frc.robot.subsystems.intakePivot.intakePivotCommands.GoToAngle;
+import frc.robot.subsystems.intakerollers.IntakeRollerConstants;
 import frc.robot.subsystems.intakerollers.IntakeRollers;
 import frc.robot.subsystems.intakerollers.rolllercommands.IntakeFuel;
 import frc.robot.subsystems.intakerollers.rolllercommands.SetIntakeVelocity;
@@ -209,7 +210,7 @@ public class RobotContainer {
 
   private void configureBindings() {
     tunnel.setDefaultCommand(new RunAtVelocity(tunnel, () -> RPM.of(0)));
-    intakeRollers.setDefaultCommand(new SetIntakeVelocity(intakeRollers, () -> RPM.of(0)));
+    intakeRollers.setDefaultCommand(Commands.run(()->intakeRollers.setVoltage(Volts.of(0)), intakeRollers));
     indexer.setDefaultCommand(new SetIndexerVelocity(indexer, () -> RPM.of(0)));
     intakePivot.setDefaultCommand(
         new GoToAngle(intakePivot, () -> IntakeConstants.kStowedPosition));
@@ -266,7 +267,8 @@ public class RobotContainer {
 
     driver.a().whileTrue(new StaticShoot(tunnel, shooter, indexer));
     driver.b().whileTrue(new Feed(tunnel, shooter, hood, indexer));
-    driver.x().whileTrue(new Release(tunnel, shooter, indexer));
+    driver.x().whileTrue(new SetIntakeVelocity(intakeRollers, intakePivot, ()->IntakeRollerConstants.kReleaseVelocity));
+    driver.povLeft().whileTrue(new Release(tunnel, shooter, indexer));
   }
 
   @Logged(name = "autonomousCommand")

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -210,7 +210,8 @@ public class RobotContainer {
 
   private void configureBindings() {
     tunnel.setDefaultCommand(new RunAtVelocity(tunnel, () -> RPM.of(0)));
-    intakeRollers.setDefaultCommand(Commands.run(()->intakeRollers.setVoltage(Volts.of(0)), intakeRollers));
+    intakeRollers.setDefaultCommand(
+        Commands.run(() -> intakeRollers.setVoltage(Volts.of(0)), intakeRollers));
     indexer.setDefaultCommand(new SetIndexerVelocity(indexer, () -> RPM.of(0)));
     intakePivot.setDefaultCommand(
         new GoToAngle(intakePivot, () -> IntakeConstants.kStowedPosition));
@@ -267,7 +268,11 @@ public class RobotContainer {
 
     driver.a().whileTrue(new StaticShoot(tunnel, shooter, indexer));
     driver.b().whileTrue(new Feed(tunnel, shooter, hood, indexer));
-    driver.x().whileTrue(new SetIntakeVelocity(intakeRollers, intakePivot, ()->IntakeRollerConstants.kReleaseVelocity));
+    driver
+        .x()
+        .whileTrue(
+            new SetIntakeVelocity(
+                intakeRollers, intakePivot, () -> IntakeRollerConstants.kReleaseVelocity));
     driver.povLeft().whileTrue(new Release(tunnel, shooter, indexer));
   }
 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -33,6 +33,7 @@ import frc.robot.subsystems.drivetrain.Drivetrain;
 import frc.robot.subsystems.drivetrain.DrivetrainConstants;
 import frc.robot.subsystems.hood.Hood;
 import frc.robot.subsystems.indexer.Indexer;
+import frc.robot.subsystems.indexer.IndexerConstants;
 import frc.robot.subsystems.indexer.indexerCommands.SetIndexerVelocity;
 import frc.robot.subsystems.intakePivot.IntakeConstants;
 import frc.robot.subsystems.intakePivot.IntakePivot;
@@ -272,7 +273,9 @@ public class RobotContainer {
         .x()
         .whileTrue(
             new SetIntakeVelocity(
-                intakeRollers, intakePivot, () -> IntakeRollerConstants.kReleaseVelocity));
+                    intakeRollers, intakePivot, () -> IntakeRollerConstants.kReleaseVelocity)
+                .alongWith(
+                    new SetIndexerVelocity(indexer, () -> IndexerConstants.kReleaseVelocity)));
     driver.povLeft().whileTrue(new Release(tunnel, shooter, indexer));
   }
 

--- a/src/main/java/frc/robot/commands/Align.java
+++ b/src/main/java/frc/robot/commands/Align.java
@@ -131,7 +131,7 @@ public final class Align {
     return drivetrain.driveFixedHeading(
         translationX,
         translationY,
-        () -> new Rotation2d(Degrees.of(180 + RobotConstants.kShooterFaceOffset.in(Degrees))));
+        () -> new Rotation2d(Degrees.of(RobotConstants.kShooterFaceOffset.in(Degrees))));
   }
 
   public static Command alignLeftClimb(Drivetrain drivetrain, Supplier<Pose2d> robotPose) {

--- a/src/main/java/frc/robot/subsystems/indexer/IndexerConstants.java
+++ b/src/main/java/frc/robot/subsystems/indexer/IndexerConstants.java
@@ -25,7 +25,7 @@ public class IndexerConstants {
 
   public static double kOscillationAmplitude = 40;
 
-  public static AngularVelocity kReleaseVelocity = RPM.of(0);
+  public static AngularVelocity kReleaseVelocity = RPM.of(-300);
 
   public static double kP = 0;
   public static double kD = 0;

--- a/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollerConstants.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/IntakeRollerConstants.java
@@ -17,7 +17,7 @@ public class IntakeRollerConstants {
   public static final Current kStatorCurrentLimit = Amps.of(60);
   public static final Current kSupplyCurrentLimit = Amps.of(60);
   public static final AngularVelocity kIntakeFuelVelocity = RPM.of(1200);
-  public static final AngularVelocity kOuttakeFuelVelocity = RPM.of(0);
+  public static final AngularVelocity kReleaseVelocity = RPM.of(-500);
   public static final AngularVelocity kMaxVelocity = RPM.of(1500);
   public static final AngularAcceleration kMaxAcceleration = RotationsPerSecondPerSecond.of(25);
   public static final double kP = 0;

--- a/src/main/java/frc/robot/subsystems/intakerollers/rolllercommands/SetIntakeVelocity.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/rolllercommands/SetIntakeVelocity.java
@@ -18,7 +18,9 @@ public class SetIntakeVelocity extends Command {
   Supplier<AngularVelocity> velocitySupplier;
 
   public SetIntakeVelocity(
-      IntakeRollers intakeRollers, IntakePivot intakePivot, Supplier<AngularVelocity> velocitySupplier) {
+      IntakeRollers intakeRollers,
+      IntakePivot intakePivot,
+      Supplier<AngularVelocity> velocitySupplier) {
     this.intakeRollers = intakeRollers;
     this.intakePivot = intakePivot;
     this.velocitySupplier = velocitySupplier;
@@ -27,9 +29,9 @@ public class SetIntakeVelocity extends Command {
 
   @Override
   public void execute() {
-    if(intakePivot.getAngle().in(Degrees)<=30){
-    intakeRollers.setTargetVelocity(velocitySupplier.get());
-    intakeRollers.goToVelocity(velocitySupplier.get());
+    if (intakePivot.getAngle().in(Degrees) <= 30) {
+      intakeRollers.setTargetVelocity(velocitySupplier.get());
+      intakeRollers.goToVelocity(velocitySupplier.get());
     }
   }
 

--- a/src/main/java/frc/robot/subsystems/intakerollers/rolllercommands/SetIntakeVelocity.java
+++ b/src/main/java/frc/robot/subsystems/intakerollers/rolllercommands/SetIntakeVelocity.java
@@ -1,35 +1,36 @@
 /* (C) RoboLancers 2026 */
 package frc.robot.subsystems.intakerollers.rolllercommands;
 
+import static edu.wpi.first.units.Units.Degrees;
 import static edu.wpi.first.units.Units.RPM;
 import static edu.wpi.first.units.Units.Volts;
 
 import edu.wpi.first.units.measure.AngularVelocity;
 import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.intakePivot.IntakePivot;
 import frc.robot.subsystems.intakerollers.IntakeRollers;
 import java.util.function.Supplier;
 
 public class SetIntakeVelocity extends Command {
 
   IntakeRollers intakeRollers;
+  IntakePivot intakePivot;
   Supplier<AngularVelocity> velocitySupplier;
 
   public SetIntakeVelocity(
-      IntakeRollers intakeRollers, Supplier<AngularVelocity> velocitySupplier) {
+      IntakeRollers intakeRollers, IntakePivot intakePivot, Supplier<AngularVelocity> velocitySupplier) {
     this.intakeRollers = intakeRollers;
+    this.intakePivot = intakePivot;
     this.velocitySupplier = velocitySupplier;
     addRequirements(intakeRollers);
   }
 
   @Override
-  public void initialize() {
-    intakeRollers.setTargetVelocity(velocitySupplier.get());
-  }
-
-  @Override
   public void execute() {
+    if(intakePivot.getAngle().in(Degrees)<=30){
     intakeRollers.setTargetVelocity(velocitySupplier.get());
     intakeRollers.goToVelocity(velocitySupplier.get());
+    }
   }
 
   @Override


### PR DESCRIPTION
 - Added intake pivot being below 30 degrees as a condition necessary before running intake rollers at velocity
 - Changed intake roller default command to zero volts (set velocity zero no longer applies constant input)
 - Change intake roller release fuel velocity to -500 rpm
 - Bound intake roller release fuel to x
 - Changed shooter release fuel (for indexing testing in pit) to pov left