### PR TITLE
R26-487: Increased shooter default rpm to 500

### DIFF
--- a/src/main/java/frc/robot/subsystems/outtake/OuttakeConstants.java
+++ b/src/main/java/frc/robot/subsystems/outtake/OuttakeConstants.java
@@ -50,7 +50,7 @@ public class OuttakeConstants {
 
   public static final AngularVelocity kStaticScoreRPM = RPM.of(700);
 
-  public static final AngularVelocity kDefaultRPM = RPM.of(100);
+  public static final AngularVelocity kDefaultRPM = RPM.of(500);
 
   public static final AngularAcceleration kMaxAcceleration = RotationsPerSecondPerSecond.of(1000);
 


### PR DESCRIPTION
Increased shooter default rpm from 100 rpm to 500 rpm